### PR TITLE
nullptr when calling SqliteExtensionEditor::validateExtension() from one of its overloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 /output*
 *.user
 .DS_Store
+*.pro.user
+**/Makefile
+**/.qmake.stash
+**/qrc_*
+SQLiteStudio3/SQLiteStudio3.pro.user.4.8-pre1

--- a/SQLiteStudio3/coreSQLiteStudio/parser/sqlite2_parse.cpp
+++ b/SQLiteStudio3/coreSQLiteStudio/parser/sqlite2_parse.cpp
@@ -1955,7 +1955,8 @@ static void yy_shift(
 /* The following table contains information about every rule that
 ** is used during the reduce.
 */
-static const struct {
+static const struct nrhs_t
+{
   YYCODETYPE lhs;         /* Symbol on the left-hand side of the rule */
   unsigned char nrhs;     /* Number of right-hand side symbols in the rule */
 } yyRuleInfo[] = {

--- a/SQLiteStudio3/coreSQLiteStudio/parser/sqlite3_parse.cpp
+++ b/SQLiteStudio3/coreSQLiteStudio/parser/sqlite3_parse.cpp
@@ -2263,7 +2263,7 @@ static void yy_shift(
 /* The following table contains information about every rule that
 ** is used during the reduce.
 */
-static const struct {
+static const struct nrhs_t{
   YYCODETYPE lhs;         /* Symbol on the left-hand side of the rule */
   unsigned char nrhs;     /* Number of right-hand side symbols in the rule */
 } yyRuleInfo[] = {

--- a/SQLiteStudio3/guiSQLiteStudio/windows/sqliteextensioneditor.h
+++ b/SQLiteStudio3/guiSQLiteStudio/windows/sqliteextensioneditor.h
@@ -61,9 +61,15 @@ class SqliteExtensionEditor : public MdiChild
         void selectExtension(int row);
         QStringList getCurrentDatabases() const;
         bool tryToLoad(const QString& filePath, const QString& initFunc, QString* resultError);
-        bool validateExtension(bool* fileOk = nullptr, bool* initOk = nullptr, QString* fileError = nullptr);
+        bool validateExtension(bool* fileOk = nullptr,
+                               bool* initOk = nullptr,
+                               QString* fileError = nullptr);
         bool validateExtension(int row);
-        bool validateExtension(const QString& filePath, const QString& initFunc, bool* fileOk = nullptr, bool* initOk = nullptr, QString* fileError = nullptr);
+        bool validateExtension(const QString& filePath,
+                               const QString& initFunc,
+                               bool* fileOk = nullptr,
+                               bool* initOk = nullptr,
+                               QString* fileError = nullptr);
         void initStateForAll();
 
         Ui::SqliteExtensionEditor *ui;


### PR DESCRIPTION
Hi, 

I have corrected a null pointer when opening extension editor that contains invalid links. 

Sorry that I wasn't able to format this pull request properly, please edit. 