### PR TITLE
Adds filtering to View data grid

### DIFF
--- a/SQLiteStudio3/guiSQLiteStudio/datagrid/sqldatasourcequerymodel.cpp
+++ b/SQLiteStudio3/guiSQLiteStudio/datagrid/sqldatasourcequerymodel.cpp
@@ -1,0 +1,137 @@
+#include "sqldatasourcequerymodel.h"
+#include "querygenerator.h"
+
+SqlDataSourceQueryModel::SqlDataSourceQueryModel(QObject *parent) :
+    SqlQueryModel(parent)
+{
+}
+
+QString SqlDataSourceQueryModel::getDatabase() const
+{
+    return database;
+}
+
+SqlQueryModel::Features SqlDataSourceQueryModel::features() const
+{
+    return FILTERING;
+}
+
+void SqlDataSourceQueryModel::updateTablesInUse(const QString& inUse)
+{
+    QString dbName = database;
+    if (database.toLower() == "main" || database.isEmpty())
+        dbName = QString();
+
+    tablesInUse.clear();
+    tablesInUse << DbAndTable(db, dbName, inUse);
+}
+
+void SqlDataSourceQueryModel::applyFilter(const QString& value, FilterValueProcessor valueProc)
+{
+    static_qstring(sql, "SELECT * FROM %1 WHERE %2");
+
+    if (value.isEmpty())
+    {
+        resetFilter();
+        return;
+    }
+
+    QStringList conditions;
+    for (SqlQueryModelColumnPtr column : columns)
+        conditions << wrapObjIfNeeded(column->getAliasedName())+" "+valueProc(value);
+
+    setQuery(sql.arg(getDataSource(), conditions.join(" OR ")));
+    executeQuery();
+}
+
+void SqlDataSourceQueryModel::applyFilter(const QStringList& values, FilterValueProcessor valueProc)
+{
+    static_qstring(sql, "SELECT * FROM %1 WHERE %2");
+    if (values.isEmpty())
+    {
+        resetFilter();
+        return;
+    }
+
+    if (values.size() != columns.size())
+    {
+        qCritical() << "Asked to per-column filter, but number columns"
+                    << columns.size() << "is different than number of values" << values.size();
+        return;
+    }
+
+    QStringList conditions;
+    for (int i = 0, total = columns.size(); i < total; ++i)
+    {
+        if (values[i].isEmpty())
+            continue;
+
+        conditions << wrapObjIfNeeded(columns[i]->getAliasedName())+" "+valueProc(values[i]);
+    }
+
+    setQuery(sql.arg(getDataSource(), conditions.join(" AND ")));
+    executeQuery();
+}
+
+QString SqlDataSourceQueryModel::stringFilterValueProcessor(const QString& value)
+{
+    static_qstring(pattern, "LIKE '%%1%'");
+    return pattern.arg(escapeString(value));
+}
+
+QString SqlDataSourceQueryModel::regExpFilterValueProcessor(const QString& value)
+{
+    static_qstring(pattern, "REGEXP '%1'");
+    return pattern.arg(escapeString(value));
+}
+
+void SqlDataSourceQueryModel::applySqlFilter(const QString& value)
+{
+    if (value.isEmpty())
+    {
+        resetFilter();
+        return;
+    }
+
+    setQuery("SELECT * FROM "+getDataSource()+" WHERE "+value);
+    executeQuery();
+}
+
+void SqlDataSourceQueryModel::applyStringFilter(const QString& value)
+{
+    applyFilter(value, &stringFilterValueProcessor);
+}
+
+void SqlDataSourceQueryModel::applyStringFilter(const QStringList& values)
+{
+    applyFilter(values, &stringFilterValueProcessor);
+}
+
+void SqlDataSourceQueryModel::applyRegExpFilter(const QString& value)
+{
+    applyFilter(value, &regExpFilterValueProcessor);
+}
+
+void SqlDataSourceQueryModel::applyRegExpFilter(const QStringList& values)
+{
+    applyFilter(values, &regExpFilterValueProcessor);
+}
+
+void SqlDataSourceQueryModel::resetFilter()
+{
+    setQuery("SELECT * FROM "+getDataSource());
+    executeQuery();
+}
+
+QString SqlDataSourceQueryModel::getDatabasePrefix()
+{
+    if (database.isNull())
+        return ""; // not "main.", because the "main." doesn't work for TEMP tables, such as sqlite_temp_master
+
+    return wrapObjIfNeeded(database) + ".";
+}
+
+QString SqlDataSourceQueryModel::getDataSource()
+{
+    return QString();
+}

--- a/SQLiteStudio3/guiSQLiteStudio/datagrid/sqldatasourcequerymodel.h
+++ b/SQLiteStudio3/guiSQLiteStudio/datagrid/sqldatasourcequerymodel.h
@@ -1,0 +1,43 @@
+#ifndef SQLDATASOURCEQUERYMODEL_H
+#define SQLDATASOURCEQUERYMODEL_H
+
+#include "sqlquerymodel.h"
+
+class SqlDataSourceQueryModel : public SqlQueryModel
+{
+    public:
+        explicit SqlDataSourceQueryModel(QObject *parent = 0);
+
+        QString getDatabase() const;
+        Features features() const;
+        void updateTablesInUse(const QString& inUse);
+
+        void applySqlFilter(const QString& value);
+        void applyStringFilter(const QString& value);
+        void applyStringFilter(const QStringList& values);
+        void applyRegExpFilter(const QString& value);
+        void applyRegExpFilter(const QStringList& values);
+        void resetFilter();
+
+    protected:
+        typedef std::function<QString(const QString&)> FilterValueProcessor;
+
+        static QString stringFilterValueProcessor(const QString& value);
+        static QString regExpFilterValueProcessor(const QString& value);
+
+        void applyFilter(const QString& value, FilterValueProcessor valueProc);
+        void applyFilter(const QStringList& values, FilterValueProcessor valueProc);
+
+        QString getDatabasePrefix();
+
+        /**
+         * @brief Get the data source for this object.
+         * Default implementation returns an empty string. Working implementation
+         * (i.e. for a table) should return the data source string.
+         */
+        virtual QString getDataSource();
+
+        QString database;
+};
+
+#endif // SQLDATASOURCEQUERYMODEL_H

--- a/SQLiteStudio3/guiSQLiteStudio/datagrid/sqlquerymodelcolumn.cpp
+++ b/SQLiteStudio3/guiSQLiteStudio/datagrid/sqlquerymodelcolumn.cpp
@@ -176,6 +176,11 @@ bool SqlQueryModelColumn::isGenerated() const
     return getConstraints<ConstraintGenerated*>().size() > 0;
 }
 
+QString SqlQueryModelColumn::getAliasedName() const
+{
+    return this->alias.isEmpty() ? this->column : this->alias;
+}
+
 QList<SqlQueryModelColumn::ConstraintFk*> SqlQueryModelColumn::getFkConstraints() const
 {
     return getConstraints<ConstraintFk*>();

--- a/SQLiteStudio3/guiSQLiteStudio/datagrid/sqlquerymodelcolumn.h
+++ b/SQLiteStudio3/guiSQLiteStudio/datagrid/sqlquerymodelcolumn.h
@@ -163,6 +163,7 @@ class GUI_API_EXPORT SqlQueryModelColumn
         bool isDefault() const;
         bool isCollate() const;
         bool isGenerated() const;
+        QString getAliasedName() const;
         QList<ConstraintFk*> getFkConstraints() const;
         ConstraintDefault* getDefaultConstraint() const;
 

--- a/SQLiteStudio3/guiSQLiteStudio/datagrid/sqltablemodel.h
+++ b/SQLiteStudio3/guiSQLiteStudio/datagrid/sqltablemodel.h
@@ -2,25 +2,18 @@
 #define SQLTABLEMODEL_H
 
 #include "guiSQLiteStudio_global.h"
-#include "sqlquerymodel.h"
+#include "sqldatasourcequerymodel.h"
 
-class GUI_API_EXPORT SqlTableModel : public SqlQueryModel
+class GUI_API_EXPORT SqlTableModel : public SqlDataSourceQueryModel
 {
         Q_OBJECT
     public:
         explicit SqlTableModel(QObject *parent = 0);
 
-        QString getDatabase() const;
         QString getTable() const;
         void setDatabaseAndTable(const QString& database, const QString& table);
 
         Features features() const;
-        void applySqlFilter(const QString& value);
-        void applyStringFilter(const QString& value);
-        void applyStringFilter(const QStringList& values);
-        void applyRegExpFilter(const QString& value);
-        void applyRegExpFilter(const QStringList& values);
-        void resetFilter();
         QString generateSelectQueryForItems(const QList<SqlQueryItem*>& items);
         QString generateInsertQueryForItems(const QList<SqlQueryItem*>& items);
         QString generateUpdateQueryForItems(const QList<SqlQueryItem*>& items);
@@ -30,6 +23,8 @@ class GUI_API_EXPORT SqlTableModel : public SqlQueryModel
     protected:
         bool commitAddedRow(const QList<SqlQueryItem*>& itemsInRow, QList<CommitSuccessfulHandler>& successfulCommitHandlers);
         bool commitDeletedRow(const QList<SqlQueryItem*>& itemsInRow, QList<CommitSuccessfulHandler>& successfulCommitHandlers);
+
+        QString getDataSource();
 
     private:
         class CommitDeleteQueryBuilder : public CommitUpdateQueryBuilder
@@ -45,13 +40,6 @@ class GUI_API_EXPORT SqlTableModel : public SqlQueryModel
                 void addColumn(const QString& col);
         };
 
-        typedef std::function<QString(const QString&)> FilterValueProcessor;
-
-        static QString stringFilterValueProcessor(const QString& value);
-        static QString regExpFilterValueProcessor(const QString& value);
-
-        void applyFilter(const QString& value, FilterValueProcessor valueProc);
-        void applyFilter(const QStringList& values, FilterValueProcessor valueProc);
         void updateColumnsAndValuesWithDefaultValues(const QList<SqlQueryModelColumnPtr>& modelColumns, QStringList& colNameList,
                                                      QStringList& sqlValues, QList<QVariant>& args);
         void updateColumnsAndValues(const QList<SqlQueryItem*>& itemsInRow, const QList<SqlQueryModelColumnPtr>& modelColumns,
@@ -65,11 +53,7 @@ class GUI_API_EXPORT SqlTableModel : public SqlQueryModel
         void processDefaultValueAfterInsert(QHash<SqlQueryModelColumnPtr,SqlQueryItem*>& columnsToReadFromDb, QHash<SqlQueryItem*,QVariant>& values,
                                             RowId rowId);
 
-        QString getDatabasePrefix();
-        QString getDataSource();
-
         QString table;
-        QString database;
         bool isWithOutRowIdTable = false;
 };
 

--- a/SQLiteStudio3/guiSQLiteStudio/datagrid/sqlviewmodel.cpp
+++ b/SQLiteStudio3/guiSQLiteStudio/datagrid/sqlviewmodel.cpp
@@ -2,7 +2,7 @@
 #include "querygenerator.h"
 
 SqlViewModel::SqlViewModel(QObject *parent) :
-    SqlQueryModel(parent)
+    SqlDataSourceQueryModel(parent)
 {
 }
 
@@ -14,7 +14,17 @@ QString SqlViewModel::generateSelectQueryForItems(const QList<SqlQueryItem*>& it
     return generator.generateSelectFromView(db, view, values);
 }
 
-void SqlViewModel::setView(const QString& view)
+void SqlViewModel::setDatabaseAndView(const QString& database, const QString& view)
 {
+    this->database = database;
     this->view = view;
+    //setQuery("SELECT * FROM "+getDataSource());
+    updateTablesInUse(view);
+
+    SchemaResolver resolver(db);
+}
+
+QString SqlViewModel::getDataSource()
+{
+    return getDatabasePrefix() + wrapObjIfNeeded(view);
 }

--- a/SQLiteStudio3/guiSQLiteStudio/datagrid/sqlviewmodel.h
+++ b/SQLiteStudio3/guiSQLiteStudio/datagrid/sqlviewmodel.h
@@ -1,15 +1,20 @@
 #ifndef SQLVIEWMODEL_H
 #define SQLVIEWMODEL_H
 
-#include "sqlquerymodel.h"
+#include "sqldatasourcequerymodel.h"
 
-class SqlViewModel : public SqlQueryModel
+class SqlViewModel : public SqlDataSourceQueryModel
 {
     public:
-        SqlViewModel(QObject *parent = 0);
+        explicit SqlViewModel(QObject *parent = 0);
+
+        QString getView() const;
 
         QString generateSelectQueryForItems(const QList<SqlQueryItem*>& items);
-        void setView(const QString& view);
+        void setDatabaseAndView(const QString& database, const QString& view);
+
+    protected:
+        QString getDataSource();
 
     private:
         QString view;

--- a/SQLiteStudio3/guiSQLiteStudio/guiSQLiteStudio.pro
+++ b/SQLiteStudio3/guiSQLiteStudio/guiSQLiteStudio.pro
@@ -51,6 +51,7 @@ SOURCES +=\
     dbtree/dbtreeitemfactory.cpp \
     sqleditor.cpp \
     datagrid/sqlquerymodel.cpp \
+    datagrid/sqldatasourcequerymodel.cpp \
     dblistmodel.cpp \
     mdiarea.cpp \
     statusfield.cpp \
@@ -203,6 +204,7 @@ HEADERS  += mainwindow.h \
     dbtree/dbtreeitemfactory.h \
     sqleditor.h \
     datagrid/sqlquerymodel.h \
+    datagrid/sqldatasourcequerymodel.h \
     dblistmodel.h \
     mdiarea.h \
     statusfield.h \

--- a/SQLiteStudio3/guiSQLiteStudio/windows/viewwindow.cpp
+++ b/SQLiteStudio3/guiSQLiteStudio/windows/viewwindow.cpp
@@ -296,7 +296,7 @@ void ViewWindow::initView()
     {
         dataModel->setDb(db);
         dataModel->setQuery(originalCreateView->select->detokenize());
-        dataModel->setView(view);
+        dataModel->setDatabaseAndView(database, view);
         ui->dbCombo->setDisabled(true);
     }
     ui->queryEdit->setDb(db);


### PR DESCRIPTION
This PR adds filtering to the View data grid/browser. It essentially duplicates the supporting functions in the datagrid table model. After testing, this approach appears to work for general filtering and column filtering - it returns correct results using string, regex, and SQL.

Resolves #3195