### PR TITLE
Strings adjustment

### DIFF
--- a/Plugins/CsvImport/CsvImportOptions.ui
+++ b/Plugins/CsvImport/CsvImportOptions.ui
@@ -62,7 +62,7 @@
    <item row="1" column="0">
     <widget class="QLabel" name="separatorLabel">
      <property name="text">
-      <string>Field separator:</string>
+      <string>Column separator:</string>
      </property>
     </widget>
    </item>

--- a/Plugins/DbAndroid/dbandroidjsonconnection.cpp
+++ b/Plugins/DbAndroid/dbandroidjsonconnection.cpp
@@ -172,7 +172,7 @@ bool DbAndroidJsonConnection::connectToDevice()
 
     if (!plugin->getAdbManager()->getDevices().contains(dbUrl.getDevice()))
     {
-        notifyWarn(tr("Cannot connect to device %1, because it's not visible to your computer.").arg(dbUrl.getDevice()));
+        notifyWarn(tr("Cannot connect to device %1, because it's not visible from your computer.").arg(dbUrl.getDevice()));
         return false;
     }
 

--- a/Plugins/DbAndroid/dbandroidshellconnection.cpp
+++ b/Plugins/DbAndroid/dbandroidshellconnection.cpp
@@ -28,7 +28,7 @@ bool DbAndroidShellConnection::connectToAndroid(const DbAndroidUrl& url)
 
     if (!adbManager->getDevices().contains(url.getDevice()))
     {
-        notifyWarn(tr("Cannot connect to device %1, because it's not visible to your computer.").arg(url.getDevice()));
+        notifyWarn(tr("Cannot connect to device %1, because it's not visible from your computer.").arg(url.getDevice()));
         return false;
     }
 

--- a/Plugins/ScriptingTcl/scriptingtcl.cpp
+++ b/Plugins/ScriptingTcl/scriptingtcl.cpp
@@ -448,7 +448,7 @@ int ScriptingTcl::dbCommand(ClientData clientData, Tcl_Interp* interp, int objc,
         return dbEvalOneColumn(ctx, interp, objv);
     }
 
-    result = Tcl_NewStringObj(tr("Invalid '%1' command sytax. Should be: %2").arg("db", "db eval sql").toUtf8().constData(), -1);
+    result = Tcl_NewStringObj(tr("Invalid '%1' command syntax. Should be: %2").arg("db", "db eval sql").toUtf8().constData(), -1);
     Tcl_SetObjResult(interp, result);
     return TCL_ERROR;
 }
@@ -460,7 +460,7 @@ int ScriptingTcl::initTclCommand(ClientData clientData, Tcl_Interp* interp, int 
 
     if (objc > 1)
     {
-        Tcl_Obj* result = Tcl_NewStringObj(tr("Error from Tcl's' '%1' command: %2").arg("tcl_init", "invalid # args: tcl_init").toUtf8().constData(), -1);
+        Tcl_Obj* result = Tcl_NewStringObj(tr("Error from Tcl's '%1' command: %2").arg("tcl_init", "invalid # args: tcl_init").toUtf8().constData(), -1);
         Tcl_SetObjResult(interp, result);
         return TCL_ERROR;
     }

--- a/SQLiteStudio3/guiSQLiteStudio/dialogs/configdialog.ui
+++ b/SQLiteStudio3/guiSQLiteStudio/dialogs/configdialog.ui
@@ -525,7 +525,7 @@
                      <string>Limit number of rows for in case of dozens of columns</string>
                     </property>
                     <property name="cfg" stdset="0">
-                     <string>General.LimitRowsForManyColumns</string>
+                     <string notr="true">General.LimitRowsForManyColumns</string>
                     </property>
                    </widget>
                   </item>
@@ -1030,7 +1030,7 @@
                  <string>Allow multiple instances of the application at the same time</string>
                 </property>
                 <property name="cfg" stdset="0">
-                 <string>General.AllowMultipleSessions</string>
+                 <string notr="true">General.AllowMultipleSessions</string>
                 </property>
                </widget>
               </item>

--- a/SQLiteStudio3/guiSQLiteStudio/windows/editorwindow.ui
+++ b/SQLiteStudio3/guiSQLiteStudio/windows/editorwindow.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string notr="true">SQL editor</string>
+   <string>SQL editor</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">
@@ -77,7 +77,7 @@
      </widget>
      <widget class="QWidget" name="results">
       <attribute name="title">
-       <string notr="true">Results</string>
+       <string>Results</string>
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_4">
        <item>

--- a/SQLiteStudio3/guiSQLiteStudio/windows/functionseditor.cpp
+++ b/SQLiteStudio3/guiSQLiteStudio/windows/functionseditor.cpp
@@ -52,7 +52,7 @@ Icon* FunctionsEditor::getIconNameForMdiWindow()
 
 QString FunctionsEditor::getTitleForMdiWindow()
 {
-    return tr("SQL function editor");
+    return tr("SQL functions editor");
 }
 
 void FunctionsEditor::createActions()

--- a/SQLiteStudio3/guiSQLiteStudio/windows/tablewindow.cpp
+++ b/SQLiteStudio3/guiSQLiteStudio/windows/tablewindow.cpp
@@ -681,7 +681,7 @@ bool TableWindow::restoreSession(const QVariant& sessionValue)
     SchemaResolver resolver(db);
     if (!resolver.getTables(database).contains(table, Qt::CaseInsensitive))
     {
-        notifyWarn(tr("Could not restore window '%1'', because the table %2 doesn't exist in the database %3.").arg(value["title"].toString(), table, db->getName()));
+        notifyWarn(tr("Could not restore window '%1', because the table %2 doesn't exist in the database %3.").arg(value["title"].toString(), table, db->getName()));
         return false;
     }
 

--- a/SQLiteStudio3/guiSQLiteStudio/windows/tablewindow.ui
+++ b/SQLiteStudio3/guiSQLiteStudio/windows/tablewindow.ui
@@ -84,7 +84,7 @@
           <item>
            <widget class="QCheckBox" name="withoutRowIdCheck">
             <property name="text">
-             <string notr="true">WITHOUT ROWID</string>
+             <string>WITHOUT ROWID</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
For i18n.

Some strings seem to be invisible, adding translation may helping to screen readers? like: 
```
  <property name="windowTitle">
   <string notr="true">SQLiteStudio completer</string>
  </property>
```
and the `<string notr="true">SQL editor</string>` & `<string notr="true">Results</string>`.