### PR TITLE
Shows backslashes on Windows for Add a database and About dialog

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -31,6 +31,7 @@
 - BUGFIX: #4084 Fixed View window refreshing when a dependant table was modified.
 - BUGFIX: Fixed error messages in debug console when executing query with less columns in results than the previously executed query.
 - BUGFIX: Fixed WITHOUT ROWID checkbox updating when table structure changes are rolled back.
+- BUGFIX: #4267 Path now shows familiar backslashes on Windows for Add a database and About dialog.
 
 ### 3.3.3
 - CHANGE: #4011 SQLite updated to 3.35.4. SQLite3MultipleCiphers updated to 1.2.4 (SQLite 3.35.4). This enables math functions from 3.35. SQLCipher updated to 4.4.3, which is only SQLite 3.34.1, so no math functions for SQLCipher.

--- a/SQLiteStudio3/coreSQLiteStudio/common/utils.cpp
+++ b/SQLiteStudio3/coreSQLiteStudio/common/utils.cpp
@@ -1106,3 +1106,8 @@ QString indentMultiline(const QString& str)
 
     return lines.join("\n");
 }
+
+QString toNativePath(const QString& path)
+{
+    return QDir::toNativeSeparators(path);
+}

--- a/SQLiteStudio3/coreSQLiteStudio/common/utils.h
+++ b/SQLiteStudio3/coreSQLiteStudio/common/utils.h
@@ -360,6 +360,8 @@ API_EXPORT QVariant deserializeFromBytes(const QByteArray& bytes);
 
 API_EXPORT QString readFileContents(const QString& path, QString* err);
 
+API_EXPORT QString toNativePath(const QString& path);
+
 Q_DECLARE_METATYPE(QList<int>)
 
 #endif // UTILS_H

--- a/SQLiteStudio3/guiSQLiteStudio/dialogs/aboutdialog.cpp
+++ b/SQLiteStudio3/guiSQLiteStudio/dialogs/aboutdialog.cpp
@@ -75,8 +75,8 @@ void AboutDialog::init(InitialMode initialMode)
     licenseContents.clear();
 
     // Environment
-    ui->appDirEdit->setText(qApp->applicationDirPath());
-    ui->cfgDirEdit->setText(CFG->getConfigDir());
+    ui->appDirEdit->setText(toNativePath(qApp->applicationDirPath()));
+    ui->cfgDirEdit->setText(toNativePath(CFG->getConfigDir()));
     ui->pluginDirList->addItems(filterResourcePaths(PLUGINS->getPluginDirs()));
     ui->iconDirList->addItems(filterResourcePaths(ICONMANAGER->getIconDirs()));
     ui->formDirList->addItems(filterResourcePaths(FORMS->getFormDirs()));
@@ -135,7 +135,8 @@ QStringList AboutDialog::filterResourcePaths(const QStringList& paths)
         if (path.startsWith(":"))
             continue;
 
-        output << path;
+        QString newPath = toNativePath(path);
+        output << newPath;
     }
     return output;
 }

--- a/SQLiteStudio3/guiSQLiteStudio/dialogs/dbdialog.cpp
+++ b/SQLiteStudio3/guiSQLiteStudio/dialogs/dbdialog.cpp
@@ -18,6 +18,7 @@
 #include <QFileDialog>
 #include <QComboBox>
 #include <QTimer>
+#include <QDir>
 
 DbDialog::DbDialog(Mode mode, QWidget *parent) :
     QDialog(parent),
@@ -44,12 +45,14 @@ void DbDialog::setPermanent(bool perm)
 
 QString DbDialog::getPath()
 {
-    return ui->fileEdit->text();
+    QString newPath = QDir::fromNativeSeparators(ui->fileEdit->text());
+    return newPath;
 }
 
 void DbDialog::setPath(const QString& path)
 {
-    ui->fileEdit->setText(path);
+    QString newPath = QDir::toNativeSeparators(path);
+    ui->fileEdit->setText(newPath);
 }
 
 QString DbDialog::getName()


### PR DESCRIPTION
Fix #4267.

Added a helper function to `common/utils.cpp`, perhaps it can be better. I once assume that more interfaces need it, but there is no found.