### PR TITLE
More backslashes & fixes for Windows

### DIFF
--- a/SQLiteStudio3/coreSQLiteStudio/services/impl/configimpl.cpp
+++ b/SQLiteStudio3/coreSQLiteStudio/services/impl/configimpl.cpp
@@ -789,7 +789,7 @@ void ConfigImpl::initDbFile()
                        " Unable to create a file at following locations: %1.").arg(pathStrings.join(", ")));
     }
 
-    qDebug() << "Using configuration directory:" << configDir;
+    qDebug().noquote() << "Using configuration directory:" << toNativePath(configDir);
     db->exec("PRAGMA foreign_keys = 1;");
 }
 
@@ -1185,7 +1185,7 @@ bool ConfigImpl::tryToMigrateOldGlobalPath(const QString& oldPath, const QString
     if (!QFileInfo::exists(oldPath))
         return false;
 
-    qDebug() << "Attempting to migrate legacy config location" << oldPath << "to new location" << newPath;
+    qDebug().noquote() << "Attempting to migrate legacy config location" << toNativePath(oldPath) << "to new location" << toNativePath(newPath);
     QDir dir = QFileInfo(newPath).dir();
     if (!dir.exists())
         QDir::root().mkpath(dir.absolutePath());

--- a/SQLiteStudio3/coreSQLiteStudio/services/impl/dbmanagerimpl.cpp
+++ b/SQLiteStudio3/coreSQLiteStudio/services/impl/dbmanagerimpl.cpp
@@ -424,7 +424,7 @@ void DbManagerImpl::rescanInvalidDatabasesForPlugin(DbPlugin* dbPlugin)
 
         if (!dbPlugin->checkIfDbServedByPlugin(db))
         {
-            qDebug() << "Managed to load database" << db->getPath() << " (" << db->getName() << ")"
+            qDebug().noquote() << "Managed to load database" << toNativePath(db->getPath()) << " (" << db->getName() << ")"
                      << "but it doesn't use DbPlugin that was just loaded, so it will not be loaded to the db manager";
 
             delete db;

--- a/SQLiteStudio3/coreSQLiteStudio/services/impl/pluginmanagerimpl.cpp
+++ b/SQLiteStudio3/coreSQLiteStudio/services/impl/pluginmanagerimpl.cpp
@@ -491,7 +491,7 @@ void PluginManagerImpl::unload(const QString& pluginName)
 
     emit unloaded(container->name, container->type);
 
-    qDebug() << pluginName << "unloaded:" << container->filePath;
+    qDebug().noquote() << pluginName << "unloaded:" << toNativePath(container->filePath);
 }
 
 bool PluginManagerImpl::load(const QString& pluginName)
@@ -604,7 +604,7 @@ void PluginManagerImpl::pluginLoaded(PluginManagerImpl::PluginContainer* contain
 
     emit loaded(container->plugin, container->type);
     if (!container->builtIn)
-        qDebug() << container->name << "loaded:" << container->filePath;
+        qDebug().noquote() << container->name << "loaded:" << toNativePath(container->filePath);
 }
 
 void PluginManagerImpl::addPluginToCollections(Plugin* plugin)

--- a/SQLiteStudio3/guiSQLiteStudio/dbtree/dbtreemodel.cpp
+++ b/SQLiteStudio3/guiSQLiteStudio/dbtree/dbtreemodel.cpp
@@ -420,7 +420,7 @@ QString DbTreeModel::getDbToolTip(DbTreeItem* item) const
         fileSize = QFile(db->getPath()).size();
 
     rows << toolTipHdrRowTmp.arg(iconPath).arg(tr("Database: %1", "dbtree tooltip").arg(db->getName()));
-    rows << toolTipRowTmp.arg("URI:").arg(db->getPath());
+    rows << toolTipRowTmp.arg(tr("URI:", "dbtree tooltip")).arg(toNativePath(db->getPath()));
 
     if (db->isValid())
     {

--- a/SQLiteStudio3/guiSQLiteStudio/dialogs/dbdialog.cpp
+++ b/SQLiteStudio3/guiSQLiteStudio/dialogs/dbdialog.cpp
@@ -102,7 +102,7 @@ void DbDialog::showEvent(QShowEvent *e)
         int idx = ui->typeCombo->findText(db->getTypeLabel());
         ui->typeCombo->setCurrentIndex(idx);
 
-        ui->fileEdit->setText(db->getPath());
+        setPath(db->getPath());
         ui->nameEdit->setText(db->getName());
         disableTypeAutodetection = false;
     }
@@ -470,7 +470,7 @@ void DbDialog::updateType()
     if (disableTypeAutodetection)
         return;
 
-    DbPlugin* validPlugin = SQLITESTUDIO->getDbManager()->getPluginForDbFile(ui->fileEdit->text());
+    DbPlugin* validPlugin = SQLITESTUDIO->getDbManager()->getPluginForDbFile(getPath());
     if (!validPlugin || validPlugin->getLabel() == ui->typeCombo->currentText())
         return;
 
@@ -501,7 +501,7 @@ bool DbDialog::testDatabase()
     if (ui->typeCombo->currentIndex() < 0)
         return false;
 
-    QString path = ui->fileEdit->text();
+    QString path = getPath();
     if (path.isEmpty())
         return false;
 
@@ -566,7 +566,7 @@ bool DbDialog::validate()
 
     if (fileState)
     {
-        registeredDb = DBLIST->getByPath(ui->fileEdit->text());
+        registeredDb = DBLIST->getByPath(getPath());
         if (registeredDb && (mode == Mode::ADD || registeredDb != db))
         {
             setValidState(ui->fileEdit, false, tr("This database is already on the list under name: %1").arg(registeredDb->getName()));
@@ -632,9 +632,9 @@ void DbDialog::valueForNameGenerationChanged()
     QString generatedName;
     DbPlugin* plugin = dbPlugins.count() > 0 ? dbPlugins[ui->typeCombo->currentText()] : nullptr;
     if (plugin)
-        generatedName = DBLIST->generateUniqueDbName(plugin, ui->fileEdit->text());
+        generatedName = DBLIST->generateUniqueDbName(plugin, getPath());
     else
-        generatedName = DBLIST->generateUniqueDbName(ui->fileEdit->text());
+        generatedName = DBLIST->generateUniqueDbName(getPath());
 
 
     ui->nameEdit->setText(generatedName);
@@ -665,10 +665,10 @@ void DbDialog::browseClicked()
 {
     if (customBrowseHandler)
     {
-        QString newUrl = customBrowseHandler(ui->fileEdit->text());
+        QString newUrl = customBrowseHandler(getPath());
         if (!newUrl.isNull())
         {
-            ui->fileEdit->setText(newUrl);
+            setPath(newUrl);
             updateState();
         }
         return;
@@ -676,7 +676,7 @@ void DbDialog::browseClicked()
 
     bool createMode = (sender() == ui->browseCreateButton);
 
-    QFileInfo fileInfo(ui->fileEdit->text());
+    QFileInfo fileInfo(getPath());
     QString dir;
     if (ui->fileEdit->text().isEmpty())
         dir = getFileDialogInitPath();

--- a/SQLiteStudio3/guiSQLiteStudio/formmanager.cpp
+++ b/SQLiteStudio3/guiSQLiteStudio/formmanager.cpp
@@ -143,7 +143,7 @@ void FormManager::loadRecurently(const QString& path, const QString& prefix)
             continue;
         }
 
-        qDebug() << "Loading form file:" << fullPath;
+        qDebug().noquote() << "Loading form file:" << toNativePath(fullPath);
 
         widgetName = getWidgetName(fullPath);
         if (widgetName.isNull())

--- a/SQLiteStudio3/sqlitestudiocli/commands/clicommanddblist.cpp
+++ b/SQLiteStudio3/sqlitestudiocli/commands/clicommanddblist.cpp
@@ -49,7 +49,7 @@ void CliCommandDbList::execute()
     for (Db* db : dbList)
     {
         bool open = db->isOpen();
-        path = db->getPath();
+        path = QDir::toNativeSeparators(db->getPath());
         name = db->getName();
         if (name == currentName)
             name.prepend("*");


### PR DESCRIPTION
Trivial, but do, like the SQLite3 shows the `\` instead of `/` or `\\` while `.databases`.

Changed to `tr("URI:", "dbtree tooltip")` to allow translated.