### PR TITLE
Change the buttons icon in dbdialog

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,7 @@
 - CHANGE: #4129 Improved memory saving algorithm, so when the colum is result of expression, the full value is always loaded immediately, to avoid subsequent query execution for loading full value when user copies cell value to clipboad.
 - CHANGE: #4071 #3437 Data column width has now more configuration options, so that it can retain its width upon entered value, or to have header contents (column name) visible.
 - CHANGE: Finalized transition to new model of translation files (using Crowdin). Generation of qm files and updating qrc files is now fully automated.
+- CHANGE: #4295 Changed icons in Database dialog.
 - CHANGE: SQLite updated to 3.35.5.
 - CHANGE: Unused the help button in title bar are removed.
 - CHANGE: #4273 Newer opened database is selected by default in the tree.

--- a/SQLiteStudio3/guiSQLiteStudio/dialogs/dbdialog.cpp
+++ b/SQLiteStudio3/guiSQLiteStudio/dialogs/dbdialog.cpp
@@ -132,7 +132,8 @@ void DbDialog::init()
 {
     ui->setupUi(this);
 
-    ui->browseCreateButton->setIcon(ICONS.PLUS);
+    ui->browseCreateButton->setIcon(ICONS.DATABASE_ADD);
+    ui->browseOpenButton->setIcon(ICONS.DATABASE_EDIT);
 
     for (DbPlugin* dbPlugin : PLUGINS->getLoadedPlugins<DbPlugin>())
         dbPlugins[dbPlugin->getLabel()] = dbPlugin;

--- a/SQLiteStudio3/guiSQLiteStudio/dialogs/dbdialog.ui
+++ b/SQLiteStudio3/guiSQLiteStudio/dialogs/dbdialog.ui
@@ -56,20 +56,12 @@
         <property name="text">
          <string/>
         </property>
-        <property name="icon">
-         <iconset resource="../icons.qrc">
-          <normaloff>:/icons/img/plus.png</normaloff>:/icons/img/plus.png</iconset>
-        </property>
        </widget>
       </item>
       <item>
        <widget class="QToolButton" name="browseOpenButton">
         <property name="text">
          <string/>
-        </property>
-        <property name="icon">
-         <iconset resource="../icons.qrc">
-          <normaloff>:/icons/img/open_sql_file.png</normaloff>:/icons/img/open_sql_file.png</iconset>
         </property>
        </widget>
       </item>
@@ -173,9 +165,7 @@
    </item>
   </layout>
  </widget>
- <resources>
-  <include location="../icons.qrc"/>
- </resources>
+ <resources/>
  <connections>
   <connection>
    <sender>buttonBox</sender>


### PR DESCRIPTION
Follow up to #4296.
Fix #4295.

Unified icons to the toolbar of main window.
Curious about the storage location of the `ICONS`, I have not found it.