### PR TITLE
Workaround for updating qtbase.qm

### DIFF
--- a/.github/workflows/lin_release.yml
+++ b/.github/workflows/lin_release.yml
@@ -72,6 +72,11 @@ jobs:
                 sudo cp -P libsqlite3.so* /usr/local/lib/
                 sudo cp *.h /usr/local/include/
 
+            - name: Workaround for updating qtbase.qm
+              shell: bash
+              run: |
+                curl https://raw.githubusercontent.com/qt/qttranslations/6.2.1/translations/qtbase_zh_CN.ts -o SQLiteStudio3/guiSQLiteStudio/translations/qtbase_zh_CN.ts  https://raw.githubusercontent.com/qt/qttranslations/6.2.1/translations/qtbase_zh_TW.ts -o SQLiteStudio3/guiSQLiteStudio/translations/qtbase_zh_TW.ts
+
             - name: Install Tcl
               run: sudo apt-get install -qq libtcl$TCL_VERSION tcl$TCL_VERSION-dev
               

--- a/.github/workflows/mac_release.yml
+++ b/.github/workflows/mac_release.yml
@@ -62,6 +62,11 @@ jobs:
               with:
                 ref: ${{ github.event.client_payload.branch }}
 
+            - name: Workaround for updating qtbase.qm
+              shell: bash
+              run: |
+                curl https://raw.githubusercontent.com/qt/qttranslations/6.2.1/translations/qtbase_zh_CN.ts -o SQLiteStudio3/guiSQLiteStudio/translations/qtbase_zh_CN.ts  https://raw.githubusercontent.com/qt/qttranslations/6.2.1/translations/qtbase_zh_TW.ts -o SQLiteStudio3/guiSQLiteStudio/translations/qtbase_zh_TW.ts
+
             - name: Install SQLite3
               run: |
                 wget http://sqlite.org/$SQLITE_RELEASE_YEAR/sqlite-amalgamation-$SQLITE_VERSION.zip

--- a/.github/workflows/win32_release.yml
+++ b/.github/workflows/win32_release.yml
@@ -56,6 +56,11 @@ jobs:
               with:
                 ref: ${{ github.event.client_payload.branch }}
 
+            - name: Workaround for updating qtbase.qm
+              shell: bash
+              run: |
+                curl https://raw.githubusercontent.com/qt/qttranslations/6.2.1/translations/qtbase_zh_CN.ts -o SQLiteStudio3/guiSQLiteStudio/translations/qtbase_zh_CN.ts  https://raw.githubusercontent.com/qt/qttranslations/6.2.1/translations/qtbase_zh_TW.ts -o SQLiteStudio3/guiSQLiteStudio/translations/qtbase_zh_TW.ts
+
             - name: Install dependencies
               shell: bash
               run: |

--- a/.github/workflows/win64_release.yml
+++ b/.github/workflows/win64_release.yml
@@ -59,6 +59,11 @@ jobs:
               with:
                 ref: ${{ github.event.client_payload.branch }}
 
+            - name: Workaround for updating qtbase.qm
+              shell: bash
+              run: |
+                curl https://raw.githubusercontent.com/qt/qttranslations/6.2.1/translations/qtbase_zh_CN.ts -o SQLiteStudio3/guiSQLiteStudio/translations/qtbase_zh_CN.ts  https://raw.githubusercontent.com/qt/qttranslations/6.2.1/translations/qtbase_zh_TW.ts -o SQLiteStudio3/guiSQLiteStudio/translations/qtbase_zh_TW.ts
+
             - name: Install dependencies
               shell: bash
               run: |

--- a/SQLiteStudio3/coreSQLiteStudio/translations.cpp
+++ b/SQLiteStudio3/coreSQLiteStudio/translations.cpp
@@ -62,6 +62,8 @@ void loadTranslations(const QStringList& baseNames)
 {
     for (const QString& name : baseNames)
         loadTranslation(name);
+    QString basefile = "qtbase";
+    loadTranslation(basefile);
 }
 
 QStringList getAvailableTranslations()


### PR DESCRIPTION
This is a dirty repair, I have tested it looks normal. I don't want it to be added to the project source code, although the Git repo is a bit messy (not is flat with git squash).

The issue is the latest Qt 5.x still does not includes the qtbase.tm for some languages. E.g. the qtbase_zh_CN.qm file does not exist in `Qt\5.15.2\mingw81_32\translations`; the `qtbase_zh_TW.qm` has appeared in Qt 5.15.2 but there seems to be incomplete translation according to tried, no localized buttons. So it causes the labels for all standard controls to keep in English instead translated, like the Yes/No, OK/Cancel/Apply, and all keyboard keys. This is an optional PR, just share it.

Note: I checked the https://wiki.qt.io/Qt_Localization & [the localization@qt-project.org mailing list](https://lists.qt-project.org/pipermail/localization/), but did not touch the upstream contact, I lack the information and faith to fix this issue in the upstream as of now, like the [5.15](https://github.com/qt/qttranslations/blob/5.15/translations/qtbase_zh_CN.ts) & [5.15-tr](https://github.com/qt/qttranslations/raw/5.15-tr/translations/qtbase_zh_CN.ts) files already available a year ago, as well as I have to try the Qt Build and fully communicate.