### PR TITLE
Shell quoting fixes

### DIFF
--- a/SQLiteStudio3/SQLiteStudio3.pro
+++ b/SQLiteStudio3/SQLiteStudio3.pro
@@ -37,9 +37,9 @@ contains(DEFINES, tests) {
 OUTPUT_DIR_NAME = output
 
 macx: {
-    bundle.commands = sh $$PWD/create_macosx_bundle.sh $$PWD/../$$OUTPUT_DIR_NAME $$QMAKE_QMAKE
-    dmg.commands = sh $$PWD/create_macosx_bundle.sh $$PWD/../$$OUTPUT_DIR_NAME $$QMAKE_QMAKE dmg
-    pkg.commands = sh $$PWD/create_macosx_bundle.sh $$PWD/../$$OUTPUT_DIR_NAME $$QMAKE_QMAKE dist
+    bundle.commands = sh \"$$PWD/create_macosx_bundle.sh\" \"$$PWD/../$$OUTPUT_DIR_NAME\" \"$$QMAKE_QMAKE\"
+    dmg.commands = sh \"$$PWD/create_macosx_bundle.sh\" \"$$PWD/../$$OUTPUT_DIR_NAME\" \"$$QMAKE_QMAKE\" dmg
+    pkg.commands = sh \"$$PWD/create_macosx_bundle.sh\" \"$$PWD/../$$OUTPUT_DIR_NAME\" \"$$QMAKE_QMAKE\" dist
     QMAKE_EXTRA_TARGETS += bundle dmg pkg
 }
 

--- a/SQLiteStudio3/coreSQLiteStudio/coreSQLiteStudio.pro
+++ b/SQLiteStudio3/coreSQLiteStudio/coreSQLiteStudio.pro
@@ -26,7 +26,7 @@ win32: {
         THE_DEST = $${DESTDIR}
         THE_FILE ~= s,/,\\,g
         THE_DEST ~= s,/,\\,g
-        QMAKE_POST_LINK += $$QMAKE_COPY $$THE_FILE $$THE_DEST $$escape_expand(\\n\\t)
+        QMAKE_POST_LINK += "$$QMAKE_COPY $$THE_FILE $$THE_DEST $$escape_expand(\\n\\t);"
     }
 }
 
@@ -40,7 +40,7 @@ linux: {
 macx: {
     out_file = $$DESTDIR/lib $$TARGET .dylib
     QMAKE_POST_LINK += install_name_tool -change libsqlite3.dylib @loader_path/../Frameworks/libsqlite3.dylib $$join(out_file)
-    QMAKE_POST_LINK += $$QMAKE_MKDIR $$DESTDIR/SQLiteStudio.app
+    QMAKE_POST_LINK += ; $$QMAKE_MKDIR $$DESTDIR/SQLiteStudio.app
     QMAKE_POST_LINK += ; $$QMAKE_MKDIR $$DESTDIR/SQLiteStudio.app/Contents
     QMAKE_POST_LINK += ; $$QMAKE_COPY $$PWD/Info.plist $$DESTDIR/SQLiteStudio.app/Contents
     LIBS += -L/usr/local/lib

--- a/SQLiteStudio3/create_macosx_bundle.sh
+++ b/SQLiteStudio3/create_macosx_bundle.sh
@@ -21,7 +21,7 @@ if [ "$?" -ne 0 ]; then
   exit 1
 fi
 
-cd $1/SQLiteStudio
+cd "$1/SQLiteStudio"
 
 rm -rf SQLiteStudio.app/Contents/Frameworks
 rm -rf SQLiteStudio.app/Contents/PlugIns
@@ -39,7 +39,7 @@ cp -RP styles/* SQLiteStudio.app/Contents/PlugIns/styles
 cp -RP lib*SQLiteStudio*.dylib SQLiteStudio.app/Contents/Frameworks
 
 # CLI paths
-qtcore_path=`otool -L sqlitestudiocli | grep QtCore | awk '{print $1;}'`
+qtcore_path=`otool -L sqlitestudiocli | awk '/QtCore/ {print $1;}'`
 new_qtcore_path="@rpath/QtCore.framework/Versions/5/QtCore"
 
 cp -P sqlitestudiocli SQLiteStudio.app/Contents/MacOS
@@ -57,7 +57,7 @@ install_name_tool -change libsqlite3.0.dylib "@rpath/libsqlite3.0.dylib" SQLiteS
 cdir=`pwd`
 cd ../../../lib/
 libdir=`pwd`
-cd $cdir
+cd "$cdir"
 
 echo "lib:"
 ls -l ../../../lib/
@@ -75,16 +75,16 @@ ls -l SQLiteStudio.app/Contents/Frameworks
 
 # Plugin paths
 function fixPluginPaths() {
-    for f in `ls $1`
+    for f in `ls "$1"`
     do
-        PLUGIN_FILE=$1/$f
-        if [ -f $PLUGIN_FILE ]; then
+        PLUGIN_FILE="$1/$f"
+        if [ -f "$PLUGIN_FILE" ]; then
     	    echo "Fixing paths for plugin $PLUGIN_FILE"
-            install_name_tool -change libcoreSQLiteStudio.1.dylib "@rpath/libcoreSQLiteStudio.1.dylib" $PLUGIN_FILE
-            install_name_tool -change libguiSQLiteStudio.1.dylib "@rpath/libguiSQLiteStudio.1.dylib" $PLUGIN_FILE
+            install_name_tool -change libcoreSQLiteStudio.1.dylib "@rpath/libcoreSQLiteStudio.1.dylib" "$PLUGIN_FILE"
+            install_name_tool -change libguiSQLiteStudio.1.dylib "@rpath/libguiSQLiteStudio.1.dylib" "$PLUGIN_FILE"
         fi
-        if [ -d $PLUGIN_FILE ]; then
-            fixPluginPaths $PLUGIN_FILE
+        if [ -d "$PLUGIN_FILE" ]; then
+            fixPluginPaths "$PLUGIN_FILE"
         fi
     done
 }
@@ -93,7 +93,7 @@ fixPluginPaths SQLiteStudio.app/Contents/PlugIns
 function replaceInfo() {
 	cdir=`pwd`
     echo Replacing Info.plist
-    cd $1/SQLiteStudio
+    cd "$1/SQLiteStudio"
     VERSION=`SQLiteStudio.app/Contents/MacOS/sqlitestudiocli -v | awk '{print $2}'`
     YEAR=`date '+%Y'`
 
@@ -102,19 +102,19 @@ function replaceInfo() {
     echo "New plist:"
     cat Info.plist.new
     mv Info.plist.new Info.plist
-	cd $cdir
+	cd "$cdir"
 }
 
 
 if [ "$3" == "dmg" ]; then
-    replaceInfo $1
-    $qt_deploy_bin SQLiteStudio.app -dmg
+    replaceInfo "$1"
+    "$qt_deploy_bin" SQLiteStudio.app -dmg
 elif [ "$3" == "dist" ]; then
-	replaceInfo $1
+	replaceInfo "$1"
 	
-	$qt_deploy_bin SQLiteStudio.app -dmg -executable=SQLiteStudio.app/Contents/MacOS/SQLiteStudio -always-overwrite -verbose=3
+	"$qt_deploy_bin" SQLiteStudio.app -dmg -executable=SQLiteStudio.app/Contents/MacOS/SQLiteStudio -always-overwrite -verbose=3
 
-	cd $1/SQLiteStudio
+	cd "$1/SQLiteStudio"
 	VERSION=`SQLiteStudio.app/Contents/MacOS/sqlitestudiocli -v | awk '{print $2}'`
 
 	mv SQLiteStudio.dmg sqlitestudio-$VERSION.dmg
@@ -127,7 +127,7 @@ elif [ "$3" == "dist" ]; then
 	hdiutil attach -readwrite sqlitestudio-rw-$VERSION.dmg
 	
 	# Fix sqlite3 file in the image
-	cp -RPf $libdir/libsqlite3.0.dylib /Volumes/SQLiteStudio/SQLiteStudio.app/Contents/Frameworks/
+	cp -RPf "$libdir/libsqlite3.0.dylib" /Volumes/SQLiteStudio/SQLiteStudio.app/Contents/Frameworks/
 
 	# Fix python dependencies in the image
 	rm -f /Volumes/SQLiteStudio/SQLiteStudio.app/Contents/Frameworks/libpython*
@@ -150,6 +150,6 @@ elif [ "$3" == "dist" ]; then
 	
     echo "Done."
 else
-    replaceInfo $1
+    replaceInfo "$1"
     $qt_deploy_bin SQLiteStudio.app
 fi

--- a/SQLiteStudio3/create_source_dist.sh
+++ b/SQLiteStudio3/create_source_dist.sh
@@ -24,7 +24,7 @@ gzip -9 ../sqlitestudio-$VERSION.tar
 
 zip -r ../sqlitestudio-$VERSION.zip SQLiteStudio3 Plugins
 
-cd $OLDDIR
+cd "$OLDDIR"
 
 mv $TEMP/sqlitestudio-$VERSION.zip ../output
 mv $TEMP/sqlitestudio-$VERSION.tar.gz ../output
@@ -35,4 +35,4 @@ rm -rf $TEMP
 
 echo "Source packages stored in `pwd`"
 
-cd $OLDDIR
+cd "$OLDDIR"

--- a/SQLiteStudio3/plugins.pri
+++ b/SQLiteStudio3/plugins.pri
@@ -95,7 +95,7 @@ macx: {
         out_file = $$join(out_file_parts)
         lib_name_parts = lib $$1 .dylib
         lib_name = $$join(lib_name_parts)
-        QMAKE_POST_LINK += install_name_tool -change $$lib_name @loader_path/../PlugIns/$$lib_name $$out_file
+        QMAKE_POST_LINK += "install_name_tool -change $$lib_name @loader_path/../PlugIns/$$lib_name \"$$out_file\";"
         export(QMAKE_POST_LINK)
 
         linker_flag_parts = -l $$1
@@ -109,7 +109,7 @@ macx: {
         out_file = $$join(out_file_parts)
         lib_name_parts = lib $$1 .dylib
         lib_name = $$join(lib_name_parts)
-        QMAKE_POST_LINK += install_name_tool -change $$lib_name @loader_path/../Frameworks/$$lib_name $$out_file
+        QMAKE_POST_LINK += "install_name_tool -change $$lib_name @loader_path/../Frameworks/$$lib_name \"$$out_file\";"
         export(QMAKE_POST_LINK)
 
         linker_flag_parts = -l $$1

--- a/scripts/macosx/compile_build_bundle.sh
+++ b/scripts/macosx/compile_build_bundle.sh
@@ -13,7 +13,7 @@ if [ "$1" == "" ]; then
 	esac
     fi
 else
-    QMAKE=$1
+    QMAKE="$1"
 fi
 
 realpath() {
@@ -22,41 +22,41 @@ realpath() {
 
 cdir=`pwd`
 cpu_cores=`sysctl -n hw.logicalcpu`
-absolute_path=`realpath $0`
-this_dir=`dirname $absolute_path`
-parent_dir=`dirname $this_dir`
-parent_dir=`dirname $parent_dir`
+absolute_path=`realpath "$0"`
+this_dir=`dirname "$absolute_path"`
+parent_dir=`dirname "$this_dir"`
+parent_dir=`dirname "$parent_dir"`
 
 if [ "$2" == "" ]; then
     read -p "Number of CPU cores to use for compiling (hit enter to use $cpu_cores): " new_cpu_cores
     case $new_cpu_cores in
 	"" ) break;;
-	* ) cpu_cores=$new_cpu_cores; break;;
+	* ) cpu_cores="$new_cpu_cores"; break;;
     esac
 else
-    cpu_cores=$2
+    cpu_cores="$2"
 fi
 
-if [ -d $parent_dir/output ]; then
+if [ -d "$parent_dir/output" ]; then
 	read -p "Directory $parent_dir/output already exists. The script will delete and recreate it. Is that okay? (y/N) : " yn
-	case $yn in
-	    [Yy]* ) rm -rf $parent_dir/output; break;;
+	case "$yn" in
+	    [Yy]* ) rm -rf "$parent_dir/output"; break;;
 	    * ) echo "Aborted."; exit;;
 	esac
 fi
 
-cd $parent_dir
-mkdir output output/build output/build/Plugins
+cd "$parent_dir"
+mkdir -p output/build/Plugins
 
 cd output/build
 $QMAKE CONFIG+=portable ../../SQLiteStudio3
-make -j $cpu_cores
+make -j "$cpu_cores" || exit 1
 
 cd Plugins
 $QMAKE CONFIG+=portable ../../../Plugins
-make -j $cpu_cores
+make -j "$cpu_cores" || exit 1
 
 cd ..
 make bundle
 
-cd $cdir
+cd "$cdir"


### PR DESCRIPTION
This mostly fixes an OS X build from path with a name containing a space character:
```
/Volumes/Mac SSD/Users/USERNAME/sqlitestudio/
```
