### PR TITLE
Don't try to use old broken system Tcl on Mac OS X

### DIFF
--- a/Plugins/ScriptingTcl/ScriptingTcl.pro
+++ b/Plugins/ScriptingTcl/ScriptingTcl.pro
@@ -81,27 +81,19 @@ linux: {
 
 macx: {
     # Find tclsh
-    #TCLSH = $$system(echo "puts 1" | tclsh)
-    #!contains(TCLSH, 1): {
-    #    error("Could not find tclsh executable. ScriptingTcl plugin requires it to find out all Tcl libraries and headers. Make tclsh available in PATH.")
-    #}
-    #TCLSH = $$system(which tclsh)
+    TCLSH = $$system(echo "puts 1" | tclsh)
+    !contains(TCLSH, 1): {
+        error("Could not find tclsh executable. ScriptingTcl plugin requires it to find out all Tcl libraries and headers. Make tclsh available in PATH.")
+    }
+    TCLSH = $$system(which tclsh)
 
     # Find its version
-    #TCL_VERSION = $$system(echo "puts [info tclversion]" | tclsh)
-    #message("Found tclsh: $$TCLSH (version: $$TCL_VERSION)")
+    TCL_VERSION = $$system(echo "puts [info tclversion]" | tclsh)
+    message("Found tclsh: $$TCLSH (version: $$TCL_VERSION)")
 
     # Find tclConfig.sh
-    #TCL_CONFIG_DIR = $$system(echo "puts [info library]" | tclsh)
-    #TCL_CONFIG = $$TCL_CONFIG_DIR/../../tclConfig.sh
-
-    XCRUN = $$system(xcrun --version)
-    !contains(XCRUN, xcrun): {
-        error("Could not find xcrun executable. ScriptingTcl plugin requires it to find out all Tcl libraries and headers.")
-    }
-
-    SDK_PATH = $$system(xcrun --show-sdk-path)
-    TCL_CONFIG = $$SDK_PATH/System/Library/Frameworks/Tcl.framework/Versions/Current/tclConfig.sh
+    TCL_CONFIG_DIR = $$system(echo "puts [info library]" | tclsh)
+    TCL_CONFIG = $$TCL_CONFIG_DIR/../tclConfig.sh
 
     # Define other libs required when linking with Tcl
     eval($$system(cat $$TCL_CONFIG | grep TCL_LIBS))


### PR DESCRIPTION
Mac OS X and its XCode SDK ship heavily outdated Tcl 8.5.9 (in OS X versions 10.13-10.15, that is; they say Tcl is deprecated in later versions) which is compiled with idiotic stack checks enabled which seem to assume Tcl_Interp objects are only being created on stack (vs. heap), resulting in "Out of stack space" errors when trying to run any Tcl code from SQLite Studio HEAD (self built), 3.3.3, 3.2.1, 3.1.1 (.dmgs downloaded from GitHub), at least in OS X 10.13 and 10.14.

This patch reverts 669375afabc133f0d0e1918e7b17d545dd7b6c34 and fixes a path to successfully link with tcl8.6 from MacPorts; I am not sure if Homebrew works the same.