### PR TITLE
Version check via sqlitestudiocli during build should not fail due to missing QT

### DIFF
--- a/SQLiteStudio3/create_macosx_bundle.sh
+++ b/SQLiteStudio3/create_macosx_bundle.sh
@@ -150,6 +150,6 @@ elif [ "$3" == "dist" ]; then
 	
     echo "Done."
 else
+    "$qt_deploy_bin" SQLiteStudio.app
     replaceInfo "$1"
-    $qt_deploy_bin SQLiteStudio.app
 fi


### PR DESCRIPTION
The patch moves QT deployment tool above sqlitestudiocli call, otherwise sqlitestudiocli fails when it can't find QT libraries in its bundle.