### PR TITLE
WIP: Allow general purpose plugins to add their configuration pages

### DIFF
--- a/SQLiteStudio3/coreSQLiteStudio/sqlitestudio.cpp
+++ b/SQLiteStudio3/coreSQLiteStudio/sqlitestudio.cpp
@@ -333,7 +333,7 @@ void SQLiteStudio::init(const QStringList& cmdListArguments, bool guiAvailable)
     pluginManager = new PluginManagerImpl();
     dbManager = new DbManagerImpl();
 
-    pluginManager->registerPluginType<GeneralPurposePlugin>(QObject::tr("General purpose", "plugin category name"));
+    pluginManager->registerPluginType<GeneralPurposePlugin>(QObject::tr("General purpose", "plugin category name"), "generalPurposePluginsPage");
     pluginManager->registerPluginType<DbPlugin>(QObject::tr("Database support", "plugin category name"));
     pluginManager->registerPluginType<CodeFormatterPlugin>(QObject::tr("Code formatter", "plugin category name"), "formatterPluginsPage");
     pluginManager->registerPluginType<ScriptingPlugin>(QObject::tr("Scripting languages", "plugin category name"));

--- a/SQLiteStudio3/guiSQLiteStudio/dialogs/configdialog.ui
+++ b/SQLiteStudio3/guiSQLiteStudio/dialogs/configdialog.ui
@@ -226,6 +226,14 @@
                <string notr="true">formatterPluginsPage</string>
               </property>
              </item>
+             <item>
+              <property name="text">
+               <string>General purpose</string>
+              </property>
+              <property name="statusTip">
+               <string notr="true">generalPurposePluginsPage</string>
+              </property>
+             </item>
             </item>
            </widget>
           </item>


### PR DESCRIPTION
This patch adds a new plugin type entry to the configuration category tree view. Only a custom plugin config form which has its plugin type entry in the tree view gets registered in the configuration dialog.
I am not sure if this change is according to your plan how it should be done.