### PR TITLE
Fixed missing QStyleFactory header

### DIFF
--- a/SQLiteStudio3/guiSQLiteStudio/windows/codesnippeteditor.cpp
+++ b/SQLiteStudio3/guiSQLiteStudio/windows/codesnippeteditor.cpp
@@ -10,6 +10,7 @@
 #include <QSortFilterProxyModel>
 #include <QItemSelection>
 #include <QDesktopServices>
+#include <QStyleFactory>
 
 CodeSnippetEditor::CodeSnippetEditor(QWidget *parent) :
     MdiChild(parent),


### PR DESCRIPTION
fix build error on macOS

SQLiteStudio3/guiSQLiteStudio/windows/codesnippeteditor.cpp:76:22: error: use of undeclared identifier 'QStyleFactory'
    QStyle *fusion = QStyleFactory::create("Fusion");
                     ^