### PR TITLE
Correct PREFIX

### DIFF
--- a/Plugins/ScriptingTcl/ScriptingTcl.pro
+++ b/Plugins/ScriptingTcl/ScriptingTcl.pro
@@ -44,7 +44,7 @@ linux: {
     !exists($$TCL_CONFIG) {
 	# Debian case
         DEBIAN_ARCH_PATH=$$system(dpkg-architecture -qDEB_HOST_MULTIARCH)
-        TCL_CONFIG = /usr/lib/$$DEBIAN_ARCH_PATH/tcl$$TCL_VERSION/tclConfig.sh
+        TCL_CONFIG = $$PREFIX/lib/$$DEBIAN_ARCH_PATH/tcl$$TCL_VERSION/tclConfig.sh
     }
     message("Looking for $$TCL_CONFIG")
     !exists($$TCL_CONFIG) {

--- a/SQLiteStudio3/Tests/TestUtils/TestUtils.pro
+++ b/SQLiteStudio3/Tests/TestUtils/TestUtils.pro
@@ -41,7 +41,7 @@ unix:!symbian {
     maemo5 {
         target.path = /opt/usr/lib
     } else {
-        target.path = /usr/lib
+        target.path = $$PREFIX/lib
     }
     INSTALLS += target
 }

--- a/SQLiteStudio3/common.pri
+++ b/SQLiteStudio3/common.pri
@@ -40,11 +40,11 @@ portable {
 
 unix: {
     isEmpty(LIBDIR) {
-	LIBDIR = /usr/lib
+	LIBDIR = $$PREFIX/lib
     }
     export(LIBDIR)
     isEmpty(BINDIR) {
-	BINDIR = /usr/bin
+	BINDIR = $$PREFIX/bin
     }
     export(BINDIR)
 }


### PR DESCRIPTION
This patch replaces hard-coded /usr prefix with the one that qmake defaults to.
This corrects the prefix on FreeBSD.
