### PR TITLE
Fix Tcl detection on Ubuntu Bionic (18.04 LTS)

### DIFF
--- a/Plugins/ScriptingTcl/ScriptingTcl.pro
+++ b/Plugins/ScriptingTcl/ScriptingTcl.pro
@@ -42,9 +42,8 @@ linux: {
 	message("Looking for $$TCL_CONFIG")
     }
     !exists($$TCL_CONFIG) {
-	# Debian case
-        DEBIAN_ARCH_PATH=$$system(dpkg-architecture -qDEB_HOST_MULTIARCH)
-        TCL_CONFIG = $$PREFIX/lib/$$DEBIAN_ARCH_PATH/tcl$$TCL_VERSION/tclConfig.sh
+	# Debian, FreeBSD, Ubuntu Bionic case
+        TCL_CONFIG = $$system(echo "puts [::tcl::pkgconfig get libdir,runtime]" | tclsh)/tcl$$TCL_VERSION/tclConfig.sh
     }
     message("Looking for $$TCL_CONFIG")
     !exists($$TCL_CONFIG) {


### PR DESCRIPTION
This fixes Tcl detection when building on Bionic. This is the same method I used for Mac before. The PREFIX variable is not being set anywhere (or by qmake), so the path was wrong.