### PR TITLE
Bundle ICU extension with release builds (#3488)

### DIFF
--- a/.github/workflows/lin_release.yml
+++ b/.github/workflows/lin_release.yml
@@ -104,6 +104,10 @@ jobs:
                     echo "gcc misc/$f.c $FLAGS -o ../../ext/$f.so"
                     gcc misc/$f.c $FLAGS -o ../../ext/$f.so
                 done
+                for f in icu; do
+                    echo "gcc icu/$f.c $FLAGS $(pkg-config --libs --cflags icu-uc icu-io) -o ../../ext/$f.so"
+                    gcc icu/$f.c $FLAGS `pkg-config --libs --cflags icu-uc icu-io` -o ../../ext/$f.so
+                done
                 ls -l ../../ext/
 
             - name: Install Tcl

--- a/.github/workflows/mac_release.yml
+++ b/.github/workflows/mac_release.yml
@@ -4,6 +4,7 @@ env:
     SQLITE_VERSION: '3400000'
     SQLITE_RELEASE_YEAR: '2022'
     PYTHON_VERSION: '3.9'
+    ICU_VERSION: '72.1'
     PORTABLE_DIR: ${{ github.workspace }}/output/portable/SQLiteStudio
     INSTALLBUILDER_DIR: ../ib
     INSTALLBUILDER_URL: https://releases.bitrock.com/installbuilder/installbuilder-enterprise-23.1.0-osx-installer.dmg
@@ -90,6 +91,14 @@ jobs:
                 sudo cp *.h /usr/local/include/
                 echo "DYLD_LIBRARY_PATH=/usr/local/lib" >> $GITHUB_ENV
 
+            - name: Install extension dependencies
+              run: |
+                brew tap-new $USER/local-tap
+                brew extract --version=$ICU_VERSION icu4c $USER/local-tap
+                brew install icu4c@$ICU_VERSION
+                echo ICU_FLAGS="$(PKG_CONFIG_PATH="/usr/local/opt/icu4c@$ICU_VERSION/lib/pkgconfig" pkg-config --libs --cflags icu-uc icu-io)" \
+                    >> $GITHUB_ENV
+
             - name: Compile additional SQLite3 extensions
               shell: bash
               run: |
@@ -101,14 +110,17 @@ jobs:
                 ls -l
                 cd sqlite-src-$SQLITE_VERSION/ext
                 ls -l
-                FLAGS="-ldl -Os -fpic -shared -Imisc -I/usr/local/include/ -L/usr/local/lib -lsqlite3"
+                FLAGS="-ldl -Os -fpic -shared -I/usr/local/include/ -L/usr/local/lib -lsqlite3"
                 for f in compress; do
-                    echo "gcc misc/$f.c $FLAGS -lz -o ../../ext/$f.dylib"
-                    gcc misc/$f.c $FLAGS -lz -o ../../ext/$f.dylib
+                    echo "gcc misc/$f.c -Imisc $FLAGS -lz -o ../../ext/$f.dylib"
+                    gcc misc/$f.c -Imisc $FLAGS -lz -o ../../ext/$f.dylib
                 done
                 for f in csv decimal eval ieee754 percentile rot13 series uint uuid zorder; do
-                    echo "gcc misc/$f.c $FLAGS -o ../../ext/$f.dylib"
-                    gcc misc/$f.c $FLAGS -o ../../ext/$f.dylib
+                    echo "gcc misc/$f.c -Imisc $FLAGS -o ../../ext/$f.dylib"
+                    gcc misc/$f.c -Imisc $FLAGS -o ../../ext/$f.dylib
+                for f in icu; do
+                    echo "gcc icu/$f.c -Iicu $ICU_FLAGS $FLAGS -o ../../ext/$f.dylib"
+                    gcc icu/$f.c -Iicu $ICU_FLAGS $FLAGS -o ../../ext/$f.dylib
                 done
                 ls -l ../../ext/
 
@@ -142,7 +154,7 @@ jobs:
               shell: bash
               run: |
                 cp -R ../ext output/SQLiteStudio/SQLiteStudio.app/Contents/extensions
-                
+
             - name: Build packages
               working-directory: output/build
               run: |

--- a/.github/workflows/win32_release.yml
+++ b/.github/workflows/win32_release.yml
@@ -4,6 +4,8 @@ env:
     SQLITE_RELEASE_YEAR: '2022'
     QT_ARCH: 'win32_mingw81'
     PYTHON_VERSION: '3.9'
+    ICU_VER: '72'
+    ICU_URL: https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-icu-72.1-1-any.pkg.tar.zst
     QT_BIN_DIR: ../Qt/5.15.2/mingw81_32/bin
     PORTABLE_DIR: output/portable/SQLiteStudio
     INSTALLBUILDER_DIR: ../ib
@@ -37,7 +39,7 @@ jobs:
               with:
                 path: ${{ github.workspace }}\..\Qt
                 key: ${{ runner.os }}-${{ env.QT_VERSION }}-Qt-Cache
-                
+
             - name: Install Qt
               uses: jurplel/install-qt-action@v3
               with:
@@ -53,7 +55,7 @@ jobs:
               with:
                 python-version: ${{ env.PYTHON_VERSION }}
                 architecture: 'x86'
-                
+
             - name: Clone repo
               uses: actions/checkout@v3
               with:
@@ -88,7 +90,14 @@ jobs:
                 cp -f sqlite3.dll ../lib/
                 cp -f sqlite3.h ../include/
                 cp -f sqlite3ext.h ../include/
-                                
+
+            - name: Install extension dependencies
+              shell: bash
+              run: |
+                cd ..
+                curl -L "$ICU_URL" | tar -xf -
+                mv mingw64 icu
+
             - name: Compile additional SQLite3 extensions
               shell: bash
               run: |
@@ -97,14 +106,18 @@ jobs:
                 curl -L http://sqlite.org/$SQLITE_RELEASE_YEAR/sqlite-src-$SQLITE_VERSION.zip --output sqlite-src-$SQLITE_VERSION.zip
                 7z x sqlite-src-$SQLITE_VERSION.zip
                 cd sqlite-src-$SQLITE_VERSION/ext
-                FLAGS="-shared -Os -fpic -DWIN32 -m32 -Imisc -I../../include -L../../lib -lsqlite3"
+                FLAGS="-shared -Os -fpic -DWIN32 -m32 -I../../include -L../../lib -lsqlite3"
                 #for f in compress; do
-                #    echo "gcc.exe misc/$f.c $FLAGS -lzlib1 -o ../../ext/$f.dll"
-                #    gcc.exe misc/$f.c $FLAGS -lzlib1 -o ../../ext/$f.dll
+                #    echo "gcc.exe misc/$f.c -Imisc $FLAGS -lzlib1 -o ../../ext/$f.dll"
+                #    gcc.exe misc/$f.c -Imisc $FLAGS -lzlib1 -o ../../ext/$f.dll
                 #done
                 for f in csv decimal eval ieee754 percentile rot13 series uint uuid zorder; do
-                    echo "gcc.exe misc/$f.c $FLAGS -o ../../ext/$f.dll"
-                    gcc.exe misc/$f.c $FLAGS -o ../../ext/$f.dll
+                    echo "gcc.exe misc/$f.c -Imisc $FLAGS -o ../../ext/$f.dll"
+                    gcc.exe misc/$f.c -Imisc $FLAGS -o ../../ext/$f.dll
+                done
+                for f in icu; do
+                    echo "gcc.exe icu/$f.c -I../../icu/include -L../../icu/lib -licuio -licuin -licuuc -licudt $FLAGS -o ../../ext/$f.dll"
+                    gcc.exe icu/$f.c -I../../icu/include -L../../icu/lib -licuio -licuin -licuuc -licudt $FLAGS -o ../../ext/$f.dll
                 done
                 ls -l ../../ext/
 
@@ -117,7 +130,7 @@ jobs:
               run: |
                 qmake.exe CONFIG+=portable "QMAKE_CXXFLAGS+=-m32" ..\..\SQLiteStudio3
                 mingw32-make.exe -j 2
-            
+
             - name: Compile Plugins
               working-directory: output/build/Plugins
               run: |
@@ -128,7 +141,7 @@ jobs:
               shell: bash
               run: |
                 cp -R ../ext output/SQLiteStudio/
-              
+
             - name: Prepare portable dir
               shell: bash
               working-directory: output
@@ -167,7 +180,9 @@ jobs:
               run: |
                 cd ../lib
                 cp *.dll "$ABSOLUTE_PORTABLE_DIR"
-                
+                cd ../icu/bin
+                cp libicuio$ICU_VER.dll libicuin$ICU_VER.dll libicuuc$ICU_VER.dll libicudt$ICU_VER.dll "$ABSOLUTE_PORTABLE_DIR"
+
             - name: Prepare portable distro (Resources)
               shell: bash
               run: |
@@ -185,7 +200,7 @@ jobs:
               run: |
                 cd $ABSOLUTE_PORTABLE_DIR/..
                 7z a -r sqlitestudio-$SQLITESTUDIO_VERSION.zip SQLiteStudio
-                
+
             - name: Install the InstalBuilder
               shell: bash
               env:
@@ -197,7 +212,7 @@ jobs:
                 echo "$IB_LICENSE" > lic.xml
                 echo "INSTALLER_SRC_PREFIX=$(pwd)" >> $GITHUB_ENV
                 echo "INSTALLER_BIN_PREFIX=$ABSOLUTE_PORTABLE_DIR" >> $GITHUB_ENV
-                
+
             - name: Create installer package
               shell: bash
               run: |

--- a/.github/workflows/win64_release.yml
+++ b/.github/workflows/win64_release.yml
@@ -4,6 +4,8 @@ env:
     SQLITE_RELEASE_YEAR: '2022'
     QT_ARCH: 'win64_mingw81'
     PYTHON_VERSION: '3.9'
+    ICU_VER: '72'
+    ICU_URL: https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-icu-72.1-1-any.pkg.tar.zst
     MINGW_DIR: ../Qt/Tools/mingw810_64
     QT_BIN_DIR: ../Qt/5.15.2/mingw81_64/bin
     PORTABLE_DIR: output/portable/SQLiteStudio
@@ -43,7 +45,7 @@ jobs:
                 # jurplel/install-qt-action has a bug due to which we cannot use ${{ github.workspace }} for the "dir" property, because it will fail.
                 dir: 'D:/'
                 setup-python: 'false'
-                
+
             - name: Install mingw
               if: steps.cache-qt.outputs.cache-hit != 'true'
               shell: bash
@@ -56,7 +58,7 @@ jobs:
               with:
                 python-version: ${{ env.PYTHON_VERSION }}
                 architecture: 'x64'
- 
+
             - name: Clone repo
               uses: actions/checkout@v3
               with:
@@ -91,7 +93,14 @@ jobs:
                 cp -f sqlite3.dll ../lib/
                 cp -f sqlite3.h ../include/
                 cp -f sqlite3ext.h ../include/
-                
+
+            - name: Install extension dependencies
+              shell: bash
+              run: |
+                cd ..
+                curl -L "$ICU_URL" | tar -xf -
+                mv mingw64 icu
+
             - name: Compile additional SQLite3 extensions
               shell: bash
               run: |
@@ -100,17 +109,20 @@ jobs:
                 curl -L http://sqlite.org/$SQLITE_RELEASE_YEAR/sqlite-src-$SQLITE_VERSION.zip --output sqlite-src-$SQLITE_VERSION.zip
                 7z x sqlite-src-$SQLITE_VERSION.zip
                 cd sqlite-src-$SQLITE_VERSION/ext
-                FLAGS="-shared -Os -fpic -DWIN64 -m64 -Imisc -I../../include -L../../lib -lsqlite3"
+                FLAGS="-shared -Os -fpic -DWIN64 -m64 -I../../include -L../../lib -lsqlite3"
                 for f in compress; do
-                    echo "gcc.exe misc/$f.c $FLAGS -lzlib1 -o ../../ext/$f.dll"
-                    gcc.exe misc/$f.c $FLAGS -lzlib1 -o ../../ext/$f.dll
+                    echo "gcc.exe misc/$f.c -Imisc $FLAGS -lzlib1 -o ../../ext/$f.dll"
+                    gcc.exe misc/$f.c -Imisc $FLAGS -lzlib1 -o ../../ext/$f.dll
                 done
                 for f in csv decimal eval ieee754 percentile rot13 series uint uuid zorder; do
-                    echo "gcc.exe misc/$f.c $FLAGS -o ../../ext/$f.dll"
-                    gcc.exe misc/$f.c $FLAGS -o ../../ext/$f.dll
+                    echo "gcc.exe misc/$f.c -Imisc $FLAGS -o ../../ext/$f.dll"
+                    gcc.exe misc/$f.c -Imisc $FLAGS -o ../../ext/$f.dll
+                for f in icu; do
+                    echo "gcc.exe icu/$f.c -I../../icu/include -L../../icu/lib -licuio -licuin -licuuc -licudt $FLAGS -o ../../ext/$f.dll"
+                    gcc.exe icu/$f.c -I../../icu/include -L../../icu/lib -licuio -licuin -licuuc -licudt $FLAGS -o ../../ext/$f.dll
                 done
                 ls -l ../../ext/
-                
+
             - name: Prepare output dir
               shell: bash
               run: mkdir output output/build output/build/Plugins
@@ -120,13 +132,13 @@ jobs:
               run: |
                 qmake.exe CONFIG+=portable ..\..\SQLiteStudio3
                 mingw32-make.exe -j 2
-            
+
             - name: Compile Plugins
               working-directory: output/build/Plugins
               run: |
                 qmake.exe CONFIG+=portable "INCLUDEPATH+=${{ env.pythonLocation }}/include" "LIBS += -L${{ env.pythonLocation }}" ..\..\..\Plugins
                 mingw32-make.exe -j 1
-              
+
             - name: Copy SQLite extensions to output dir
               shell: bash
               run: |
@@ -170,7 +182,9 @@ jobs:
               run: |
                 cd ../lib
                 cp *.dll "$ABSOLUTE_PORTABLE_DIR"
-                
+                cd ../icu/bin
+                cp libicuio$ICU_VER.dll libicuin$ICU_VER.dll libicuuc$ICU_VER.dll libicudt$ICU_VER.dll "$ABSOLUTE_PORTABLE_DIR"
+
             - name: Prepare portable distro (Resources)
               shell: bash
               run: |
@@ -188,7 +202,7 @@ jobs:
               run: |
                 cd $ABSOLUTE_PORTABLE_DIR/..
                 7z a -r sqlitestudio-$SQLITESTUDIO_VERSION.zip SQLiteStudio
-                
+
             - name: Install the InstalBuilder
               shell: bash
               env:
@@ -200,7 +214,7 @@ jobs:
                 echo "$IB_LICENSE" > lic.xml
                 echo "INSTALLER_SRC_PREFIX=$(pwd)" >> $GITHUB_ENV
                 echo "INSTALLER_BIN_PREFIX=$ABSOLUTE_PORTABLE_DIR" >> $GITHUB_ENV
-                
+
             - name: Create installer package
               shell: bash
               run: |


### PR DESCRIPTION
This PR adds prebuilt SQLite ICU extension for all 4 release platforms.

Non-Linux installs are ~30 MB bigger (ICU 72.1 libraries); on Linux, SQLiteStudio already includes ICU 56 libraries as a dependency of QT, so I decided to keep these.

On Mac, ICU libs are built by Homebrew.

On Windows, MSYS2 MinGW-W64 binary packages are used, because the upstream ICU Windows binaries add an extra dependency on MS Visual C++ runtime (vcredist.exe).