### PR TITLE
Enable opt-in ccache for manual Github Actions workflow runs

### DIFF
--- a/.github/workflows/lin_release.yml
+++ b/.github/workflows/lin_release.yml
@@ -13,6 +13,10 @@ name: Linux release build
 on:
     workflow_dispatch:
         inputs:
+          use_ccache:
+            description: 'Use ccache (for workflow debugging only!)'
+            required: false
+            type: boolean
     schedule:
         - cron: '30 3 * * 1' # run at 3:30 AM UTC every Monday
     repository_dispatch:
@@ -27,11 +31,11 @@ jobs:
               with:
                 python-version: ${{ env.PYTHON_VERSION }}
                 architecture: 'x64'
-              
+
             - name: Qt installation dir
               id: qt-installation-dir
               run: echo "DIR=$(readlink -f ${{ github.workspace }}/..)" >> $GITHUB_OUTPUT
-              
+
             - name: Install Qt
               uses: jurplel/install-qt-action@v3
               with:
@@ -43,7 +47,7 @@ jobs:
                 py7zrversion: '==0.20.*'
                 setup-python: 'false'
                 extra: '--external 7z'
-                
+
             - name: Install the InstalBuilder
               shell: bash
               run: |
@@ -64,6 +68,18 @@ jobs:
               run: |
                 cd ..
                 curl -L http://sqlite.org/$SQLITE_RELEASE_YEAR/sqlite-src-$SQLITE_VERSION.zip --output sqlite-src-$SQLITE_VERSION.zip
+
+            - name: Prepare ccache
+              if: inputs.use_ccache || false
+              uses: hendrikmuhs/ccache-action@v1.2.8
+              with:
+                key: lin_release
+                max-size: "24M"
+
+            - name: Configure ccache
+              if: inputs.use_ccache || false
+              run: |
+                echo "PATH=/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH" >> $GITHUB_ENV
 
             - name: Install SQLite3
               run: |
@@ -112,7 +128,7 @@ jobs:
 
             - name: Install Tcl
               run: sudo apt-get install -qq libtcl$TCL_VERSION tcl$TCL_VERSION-dev
-              
+
             - name: Install other tools/dependencies
               run: |
                 sudo apt install libreadline-dev libncurses5-dev patchelf chrpath
@@ -120,24 +136,31 @@ jobs:
 
             - name: Prepare output dir
               run: mkdir output output/build output/build/Plugins
-            
+
             - name: Compile SQLiteStudio3
               working-directory: output/build
               run: |
-                qmake CONFIG+=portable ../../SQLiteStudio3
+                qmake \
+                    $([ ${{ inputs.use_ccache || false }} = false ] || echo "CONFIG+=ccache") \
+                    CONFIG+=portable \
+                    ../../SQLiteStudio3
                 make -j 2
-            
+
             - name: Compile Plugins
               working-directory: output/build/Plugins
               run: |
-                qmake CONFIG+=portable "INCLUDEPATH+=$pythonLocation/include/python$PYTHON_VERSION" "LIBS += -L$pythonLocation/lib" ../../../Plugins
+                qmake \
+                    $([ ${{ inputs.use_ccache || false }} = false ] || echo "CONFIG+=ccache") \
+                    CONFIG+=portable \
+                    "INCLUDEPATH+=$pythonLocation/include/python$PYTHON_VERSION" "LIBS += -L$pythonLocation/lib" \
+                    ../../../Plugins
                 make -j 1
 
             - name: Copy SQLite extensions to output dir
               shell: bash
               run: |
                 cp -R ../ext output/SQLiteStudio/extensions
-              
+
             - name: Prepare portable dir
               working-directory: output
               run: |
@@ -154,7 +177,7 @@ jobs:
                 LIBCRYPTO=$(ldd plugins/libDbSqliteCipher.so | grep crypto | awk '{print $3}')
                 REAL_LIBCRYPTO=$(readlink -e $LIBCRYPTO)
                 cp -P $REAL_LIBCRYPTO lib/$(basename -- $LIBCRYPTO)
-                
+
             - name: Copy Qt's libcrypto and libssl to portable dir (#4577)
               run: |
                 wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.17_amd64.deb

--- a/.github/workflows/mac_release.yml
+++ b/.github/workflows/mac_release.yml
@@ -14,6 +14,10 @@ name: MacOSX release build
 on:
     workflow_dispatch:
         inputs:
+          use_ccache:
+            description: 'Use ccache (for workflow debugging only!)'
+            required: false
+            type: boolean
     schedule:
         - cron: '0 3 * * 1' # run at 3 AM UTC every Monday
     repository_dispatch:
@@ -68,6 +72,18 @@ jobs:
               with:
                 ref: ${{ github.event.client_payload.branch }}
 
+            - name: Prepare ccache
+              if: inputs.use_ccache || false
+              uses: hendrikmuhs/ccache-action@v1.2.8
+              with:
+                key: mac_release
+                max-size: "24M"
+
+            - name: Configure ccache
+              if: inputs.use_ccache || false
+              run: |
+                echo "PATH=/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH" >> $GITHUB_ENV
+
             - name: Install SQLite3
               run: |
                 wget http://sqlite.org/$SQLITE_RELEASE_YEAR/sqlite-amalgamation-$SQLITE_VERSION.zip
@@ -110,7 +126,7 @@ jobs:
                 ls -l
                 cd sqlite-src-$SQLITE_VERSION/ext
                 ls -l
-                FLAGS="-ldl -Os -fpic -shared -I/usr/local/include/ -L/usr/local/lib -lsqlite3"
+                FLAGS="-ldl -Os -fpic -shared -I/usr/local/include -L/usr/local/lib -lsqlite3"
                 for f in compress sqlar; do
                     echo "gcc misc/$f.c -Imisc $FLAGS -lz -o ../../ext/$f.dylib"
                     gcc misc/$f.c -Imisc $FLAGS -lz -o ../../ext/$f.dylib
@@ -142,13 +158,20 @@ jobs:
             - name: Compile SQLiteStudio3
               working-directory: output/build
               run: |
-                qmake CONFIG+=portable ../../SQLiteStudio3
+                qmake \
+                    $([ ${{ inputs.use_ccache || false }} = false ] || echo "CONFIG+=ccache") \
+                    CONFIG+=portable \
+                    ../../SQLiteStudio3
                 make -j 2
 
             - name: Compile Plugins
               working-directory: output/build/Plugins
               run: |
-                qmake CONFIG+=portable "INCLUDEPATH+=$pythonLocation/include/python$PYTHON_VERSION" "LIBS += -L$pythonLocation/lib" ../../../Plugins
+                qmake \
+                    $([ ${{ inputs.use_ccache || false }} = false ] || echo "CONFIG+=ccache") \
+                    CONFIG+=portable \
+                    "INCLUDEPATH+=$pythonLocation/include/python$PYTHON_VERSION" "LIBS += -L$pythonLocation/lib" \
+                    ../../../Plugins
                 make -j 1
 
             - name: Copy SQLite extensions to output dir

--- a/.github/workflows/win32_release.yml
+++ b/.github/workflows/win32_release.yml
@@ -17,6 +17,10 @@ name: Windows 32-bit release build
 on:
     workflow_dispatch:
         inputs:
+          use_ccache:
+            description: 'Use ccache (for workflow debugging only!)'
+            required: false
+            type: boolean
     schedule:
         - cron: '30 2 * * 1' # run at 2 AM UTC every Monday
     repository_dispatch:
@@ -66,7 +70,23 @@ jobs:
               run: |
                 7z x -o".." win_deps/win32_deps.zip
                 echo "../lib" >> $GITHUB_PATH
- 
+
+            - name: Prepare ccache
+              if: inputs.use_ccache || false
+              uses: hendrikmuhs/ccache-action@v1.2.8
+              with:
+                key: win32_release
+                max-size: "24M"
+
+            - name: Configure ccache (or not ccache)
+              shell: bash
+              run: |
+                if [ ${{ inputs.use_ccache || false }} = false ]; then
+                    printf 'GCC_COMMAND=gcc.exe\nGXX_COMMAND=g++.exe\n'
+                else
+                    printf 'GCC_COMMAND=ccache.exe gcc.exe\nGXX_COMMAND=ccache.exe g++.exe\n'
+                fi >> $GITHUB_ENV
+
             - name: Install SQLite3
               shell: bash
               run: |
@@ -74,7 +94,7 @@ jobs:
                 curl -L http://sqlite.org/$SQLITE_RELEASE_YEAR/sqlite-amalgamation-$SQLITE_VERSION.zip --output sqlite-amalgamation-$SQLITE_VERSION.zip
                 7z x sqlite-amalgamation-$SQLITE_VERSION.zip
                 cd sqlite-amalgamation-$SQLITE_VERSION
-                gcc.exe sqlite3.c -Os -fpic -DWIN32 -m32 -I. -shared -o sqlite3.dll \
+                $GCC_COMMAND sqlite3.c -Os -fpic -DWIN32 -m32 -I. -shared -o sqlite3.dll \
                     -DSQLITE_ENABLE_UPDATE_DELETE_LIMIT \
                     -DSQLITE_ENABLE_DBSTAT_VTAB \
                     -DSQLITE_ENABLE_BYTECODE_VTAB \
@@ -108,16 +128,16 @@ jobs:
                 cd sqlite-src-$SQLITE_VERSION/ext
                 FLAGS="-shared -Os -fpic -DWIN32 -m32 -I../../include -L../../lib -lsqlite3"
                 #for f in compress sqlar; do
-                #    echo "gcc.exe misc/$f.c -Imisc $FLAGS -lzlib1 -o ../../ext/$f.dll"
-                #    gcc.exe misc/$f.c -Imisc $FLAGS -lzlib1 -o ../../ext/$f.dll
+                #    echo "$GCC_COMMAND misc/$f.c -Imisc $FLAGS -lzlib1 -o ../../ext/$f.dll"
+                #    $GCC_COMMAND misc/$f.c -Imisc $FLAGS -lzlib1 -o ../../ext/$f.dll
                 #done
                 for f in csv decimal eval ieee754 percentile rot13 series uint uuid zorder; do
-                    echo "gcc.exe misc/$f.c -Imisc $FLAGS -o ../../ext/$f.dll"
-                    gcc.exe misc/$f.c -Imisc $FLAGS -o ../../ext/$f.dll
+                    echo "$GCC_COMMAND misc/$f.c -Imisc $FLAGS -o ../../ext/$f.dll"
+                    $GCC_COMMAND misc/$f.c -Imisc $FLAGS -o ../../ext/$f.dll
                 done
                 for f in icu; do
-                    echo "gcc.exe icu/$f.c -I../../icu/include -L../../icu/lib -licuio -licuin -licuuc -licudt $FLAGS -o ../../ext/$f.dll"
-                    gcc.exe icu/$f.c -I../../icu/include -L../../icu/lib -licuio -licuin -licuuc -licudt $FLAGS -o ../../ext/$f.dll
+                    echo "$GCC_COMMAND icu/$f.c -I../../icu/include -L../../icu/lib -licuio -licuin -licuuc -licudt $FLAGS -o ../../ext/$f.dll"
+                    $GCC_COMMAND icu/$f.c -I../../icu/include -L../../icu/lib -licuio -licuin -licuuc -licudt $FLAGS -o ../../ext/$f.dll
                 done
                 ls -l ../../ext/
 
@@ -128,13 +148,22 @@ jobs:
             - name: Compile SQLiteStudio3
               working-directory: output/build
               run: |
-                qmake.exe CONFIG+=portable "QMAKE_CXXFLAGS+=-m32" ..\..\SQLiteStudio3
+                qmake.exe `
+                    CONFIG+=portable `
+                    "QMAKE_CXX=${{ env.GXX_COMMAND }}" `
+                    "QMAKE_CXXFLAGS+=-m32" `
+                    ..\..\SQLiteStudio3
                 mingw32-make.exe -j 2
 
             - name: Compile Plugins
               working-directory: output/build/Plugins
               run: |
-                qmake.exe CONFIG+=portable "INCLUDEPATH+=${{ env.pythonLocation }}/include" "LIBS += -L${{ env.pythonLocation }}" "QMAKE_CXXFLAGS+=-m32" ..\..\..\Plugins 
+                qmake.exe `
+                    "QMAKE_CXX=${{ env.GXX_COMMAND }}" `
+                    CONFIG+=portable `
+                    "INCLUDEPATH+=${{ env.pythonLocation }}/include" "LIBS += -L${{ env.pythonLocation }}" `
+                    "QMAKE_CXXFLAGS+=-m32" `
+                    ..\..\..\Plugins
                 mingw32-make.exe -j 1
 
             - name: Copy SQLite extensions to output dir

--- a/.github/workflows/win64_release.yml
+++ b/.github/workflows/win64_release.yml
@@ -18,6 +18,10 @@ name: Windows 64-bit release build
 on:
     workflow_dispatch:
         inputs:
+          use_ccache:
+            description: 'Use ccache (for workflow debugging only!)'
+            required: false
+            type: boolean
     schedule:
         - cron: '0 2 * * 1' # run at 2 AM UTC every Monday
     repository_dispatch:
@@ -69,7 +73,23 @@ jobs:
               run: |
                 7z x -o".." win_deps/win64_deps.zip
                 echo "../lib" >> $GITHUB_PATH
- 
+
+            - name: Prepare ccache
+              if: inputs.use_ccache || false
+              uses: hendrikmuhs/ccache-action@v1.2.8
+              with:
+                key: win64_release
+                max-size: "24M"
+
+            - name: Configure ccache (or not ccache)
+              shell: bash
+              run: |
+                if [ ${{ inputs.use_ccache || false }} = false ]; then
+                    printf 'GCC_COMMAND=gcc.exe\nGXX_COMMAND=g++.exe\n'
+                else
+                    printf 'GCC_COMMAND=ccache.exe gcc.exe\nGXX_COMMAND=ccache.exe g++.exe\n'
+                fi >> $GITHUB_ENV
+
             - name: Install SQLite3
               shell: bash
               run: |
@@ -77,7 +97,7 @@ jobs:
                 curl -L http://sqlite.org/$SQLITE_RELEASE_YEAR/sqlite-amalgamation-$SQLITE_VERSION.zip --output sqlite-amalgamation-$SQLITE_VERSION.zip
                 7z x sqlite-amalgamation-$SQLITE_VERSION.zip
                 cd sqlite-amalgamation-$SQLITE_VERSION
-                gcc.exe sqlite3.c -Os -fpic -DWIN64 -m64 -I. -shared -o sqlite3.dll \
+                $GCC_COMMAND sqlite3.c -Os -fpic -DWIN64 -m64 -I. -shared -o sqlite3.dll \
                     -DSQLITE_ENABLE_UPDATE_DELETE_LIMIT \
                     -DSQLITE_ENABLE_DBSTAT_VTAB \
                     -DSQLITE_ENABLE_BYTECODE_VTAB \
@@ -111,16 +131,16 @@ jobs:
                 cd sqlite-src-$SQLITE_VERSION/ext
                 FLAGS="-shared -Os -fpic -DWIN64 -m64 -I../../include -L../../lib -lsqlite3"
                 for f in compress sqlar; do
-                    echo "gcc.exe misc/$f.c -Imisc $FLAGS -lzlib1 -o ../../ext/$f.dll"
-                    gcc.exe misc/$f.c -Imisc $FLAGS -lzlib1 -o ../../ext/$f.dll
+                    echo "$GCC_COMMAND misc/$f.c -Imisc $FLAGS -lzlib1 -o ../../ext/$f.dll"
+                    $GCC_COMMAND misc/$f.c -Imisc $FLAGS -lzlib1 -o ../../ext/$f.dll
                 done
                 for f in csv decimal eval ieee754 percentile rot13 series uint uuid zorder; do
-                    echo "gcc.exe misc/$f.c -Imisc $FLAGS -o ../../ext/$f.dll"
-                    gcc.exe misc/$f.c -Imisc $FLAGS -o ../../ext/$f.dll
+                    echo "$GCC_COMMAND misc/$f.c -Imisc $FLAGS -o ../../ext/$f.dll"
+                    $GCC_COMMAND misc/$f.c -Imisc $FLAGS -o ../../ext/$f.dll
                 done
                 for f in icu; do
-                    echo "gcc.exe icu/$f.c -I../../icu/include -L../../icu/lib -licuio -licuin -licuuc -licudt $FLAGS -o ../../ext/$f.dll"
-                    gcc.exe icu/$f.c -I../../icu/include -L../../icu/lib -licuio -licuin -licuuc -licudt $FLAGS -o ../../ext/$f.dll
+                    echo "$GCC_COMMAND icu/$f.c -I../../icu/include -L../../icu/lib -licuio -licuin -licuuc -licudt $FLAGS -o ../../ext/$f.dll"
+                    $GCC_COMMAND icu/$f.c -I../../icu/include -L../../icu/lib -licuio -licuin -licuuc -licudt $FLAGS -o ../../ext/$f.dll
                 done
                 ls -l ../../ext/
 
@@ -131,13 +151,20 @@ jobs:
             - name: Compile SQLiteStudio3
               working-directory: output/build
               run: |
-                qmake.exe CONFIG+=portable ..\..\SQLiteStudio3
+                qmake.exe `
+                    CONFIG+=portable `
+                    "QMAKE_CXX=${{ env.GXX_COMMAND }}" `
+                    ..\..\SQLiteStudio3
                 mingw32-make.exe -j 2
 
             - name: Compile Plugins
               working-directory: output/build/Plugins
               run: |
-                qmake.exe CONFIG+=portable "INCLUDEPATH+=${{ env.pythonLocation }}/include" "LIBS += -L${{ env.pythonLocation }}" ..\..\..\Plugins
+                qmake.exe `
+                    "QMAKE_CXX=${{ env.GXX_COMMAND }}" `
+                    CONFIG+=portable `
+                    "INCLUDEPATH+=${{ env.pythonLocation }}/include" "LIBS += -L${{ env.pythonLocation }}" `
+                    ..\..\..\Plugins
                 mingw32-make.exe -j 1
 
             - name: Copy SQLite extensions to output dir


### PR DESCRIPTION
Although enabling ccache for release builds should not be done normally, there are times when you need to debug the workflow itself, running it hundreds of times repeatedly. In these moments, speedup provided by ccache is crucial. This PR adds a checkbox (disabled by default) to enable ccache next to the manual workflow run button.