### PR TITLE
ScriptingQT: Fix seemingly nonfunctional code; fix building with pre-5.14 Qt versions

### DIFF
--- a/SQLiteStudio3/coreSQLiteStudio/plugins/scriptingqt.cpp
+++ b/SQLiteStudio3/coreSQLiteStudio/plugins/scriptingqt.cpp
@@ -232,7 +232,11 @@ void ScriptingQt::deinit()
     QMutexLocker locker(managedMainContextsMutex);
     for (ContextQt*& ctx : managedMainContexts)
     {
-        ctx->engine->isInterrupted();
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+        ctx->engine->setInterrupted(true);
+#else
+        // FIXME No way to cleanly interrupt QJSEngine before Qt 5.14
+#endif
         delete ctx;
     }
 


### PR DESCRIPTION
@pawelsalawa I am not quite sure you meant to call setInterrupted(true), but calling isInterrupted() here seems to ignore its return value. Also, added an #if guard for older Qt versions.