### PR TITLE
Plugins: allow to compile with Python 3.11

### DIFF
--- a/Plugins/ScriptingPython/scriptingpython.cpp
+++ b/Plugins/ScriptingPython/scriptingpython.cpp
@@ -582,15 +582,25 @@ SqlQueryPtr ScriptingPython::dbCommonEval(PyObject* sqlArg, const char* fnName)
 QVariant ScriptingPython::getVariable(const QString& name)
 {
     PyThreadState* state = PyThreadState_Get();
-    if (!state->frame)
+#if PY_VERSION_HEX < 0x03090000
+    PyFrameObject* frame = state->frame;
+#else
+    PyFrameObject* frame = PyThreadState_GetFrame(state);
+#endif
+    if (!frame)
         return QVariant();
 
     const char* varName = name.toUtf8().constData();
     PyObject* obj = nullptr;
 
-    PyFrame_FastToLocals(state->frame);
-    PyObject* locals = state->frame->f_locals;
-    PyObject* globals = state->frame->f_globals;
+    PyFrame_FastToLocals(frame);
+#if PY_VERSION_HEX < 0x03090000
+    PyObject* locals = frame->f_locals;
+    PyObject* globals = frame->f_globals;
+#else
+    PyObject* locals = PyFrame_GetLocals(frame);
+    PyObject* globals = PyFrame_GetGlobals(frame);
+#endif
     if (PyMapping_Check(locals))
         obj = PyMapping_GetItemString(locals, varName);
     else if (PyDict_Check(globals))


### PR DESCRIPTION
Hello,
I was having troubles compiling under Gentoo GNU/Linux with Python 3.11 (the new default Python version on Gentoo).

This PR addresses just the compilation, I'm not aware of side effects when using Pytong 3.11, but the program seems to run fine and there are no apparent issues connecting to a database.

```
git clone https://github.com/pawelsalawa/sqlitestudio.git
cd sqlitestudio
mkdir -p output/build/Plugins
cd output/build
qmake5 ../../SQLiteStudio3
make
cd Plugins
qmake5 ../../../Plugins "INCLUDEPATH += /usr/include/python3.11" "PYTHON_VERSION=3.11"
make
```

Python 3.11 removed `PyThreadState()->frame`, but since Python 3.9 `PyThreadState_GetFrame()` can be used to get the frame.  Also, to get the frame's `f_locals` and `f_globals` the methods `PyFrame_GetLocals()` and `PyFrame_GetGlobals()` can be used when compiling with Python 3.11.

References:
- https://docs.python.org/3/c-api/frame.html