### PR TITLE
PoC: Store script functions as a table for easier bulk import/export

### DIFF
--- a/SQLiteStudio3/Tests/TestUtils/configmock.cpp
+++ b/SQLiteStudio3/Tests/TestUtils/configmock.cpp
@@ -231,6 +231,15 @@ void ConfigMock::refreshDdlHistory()
 {
 }
 
+QList<QHash<QString, QVariant> > ConfigMock::getScriptFunctions()
+{
+    return QList<QHash<QString, QVariant> >();
+}
+
+void ConfigMock::setScriptFunctions(const QList<QHash<QString, QVariant> >&)
+{
+}
+
 QString ConfigMock::getSqlite3Version() const
 {
     return "3.8.8";

--- a/SQLiteStudio3/Tests/TestUtils/configmock.h
+++ b/SQLiteStudio3/Tests/TestUtils/configmock.h
@@ -47,6 +47,8 @@ class ConfigMock : public Config
         QList<DdlHistoryEntryPtr> getDdlHistoryFor(const QString&, const QString&, const QDate&);
         DdlHistoryModel* getDdlHistoryModel();
         void clearDdlHistory();
+        QList<QHash<QString, QVariant> > getScriptFunctions();
+        void setScriptFunctions(const QList<QHash<QString, QVariant> >&);
         void begin();
         void commit();
         void rollback();

--- a/SQLiteStudio3/coreSQLiteStudio/services/config.h
+++ b/SQLiteStudio3/coreSQLiteStudio/services/config.h
@@ -12,7 +12,7 @@
 #include <QSharedPointer>
 #include <QDateTime>
 
-const int SQLITESTUDIO_CONFIG_VERSION = 3;
+const int SQLITESTUDIO_CONFIG_VERSION = 4;
 
 CFG_CATEGORIES(Core,
     CFG_CATEGORY(General,
@@ -29,7 +29,6 @@ CFG_CATEGORIES(Core,
         CFG_ENTRY(int,          HistorySize,             100)
     )
     CFG_CATEGORY(Internal,
-        CFG_ENTRY(QVariantList, Functions,               QVariantList())
         CFG_ENTRY(QVariantList, Collations,              QVariantList())
         CFG_ENTRY(QVariantList, Extensions,              QVariantList())
         CFG_ENTRY(QVariantList, CodeSnippets,            QVariantList())
@@ -184,6 +183,9 @@ class API_EXPORT Config : public QObject
         virtual QList<ReportHistoryEntryPtr> getReportHistory() = 0;
         virtual void deleteReport(int id) = 0;
         virtual void clearReportHistory() = 0;
+
+        virtual QList<QHash<QString, QVariant> > getScriptFunctions() = 0;
+        virtual void setScriptFunctions(const QList<QHash<QString, QVariant> >& newFunctions) = 0;
 
         virtual void begin() = 0;
         virtual void commit() = 0;

--- a/SQLiteStudio3/coreSQLiteStudio/services/impl/configimpl.cpp
+++ b/SQLiteStudio3/coreSQLiteStudio/services/impl/configimpl.cpp
@@ -618,6 +618,12 @@ QString ConfigImpl::getLegacyConfigPath()
 #endif
 }
 
+void ConfigImpl::dropTables(const QList<QString>& tables)
+{
+    for (const QString& table : tables)
+        db->exec("DROP TABLE " + table);
+}
+
 void ConfigImpl::initTables()
 {
     SqlQueryPtr results = db->exec("SELECT lower(name) AS name FROM sqlite_master WHERE type = 'table'");
@@ -625,9 +631,7 @@ void ConfigImpl::initTables()
 
     if (!tables.contains("version"))
     {
-        for (const QString& table : tables)
-            db->exec("DROP TABLE "+table);
-
+        dropTables(tables);
         tables.clear();
         db->exec("CREATE TABLE version (version NUMERIC)");
         db->exec("INSERT INTO version VALUES ("+QString::number(SQLITESTUDIO_CONFIG_VERSION)+")");

--- a/SQLiteStudio3/coreSQLiteStudio/services/impl/configimpl.h
+++ b/SQLiteStudio3/coreSQLiteStudio/services/impl/configimpl.h
@@ -113,6 +113,7 @@ class API_EXPORT ConfigImpl : public Config
         void storeGroup(const DbGroupPtr& group, qint64 parentId = -1);
         void readGroupRecursively(DbGroupPtr group);
         QString getConfigPath();
+        void dropTables(const QList<QString>& tables);
         void initTables();
         void initDbFile();
         QList<ConfigDirCandidate> getStdDbPaths();

--- a/SQLiteStudio3/coreSQLiteStudio/services/impl/configimpl.h
+++ b/SQLiteStudio3/coreSQLiteStudio/services/impl/configimpl.h
@@ -86,6 +86,9 @@ class API_EXPORT ConfigImpl : public Config
         void deleteReport(int id);
         void clearReportHistory();
 
+        QList<QHash<QString, QVariant> > getScriptFunctions();
+        void setScriptFunctions(const QList<QHash<QString, QVariant> >& newFunctions);
+
         void begin();
         void commit();
         void rollback();

--- a/SQLiteStudio3/coreSQLiteStudio/services/impl/functionmanagerimpl.cpp
+++ b/SQLiteStudio3/coreSQLiteStudio/services/impl/functionmanagerimpl.cpp
@@ -352,6 +352,7 @@ void FunctionManagerImpl::storeInConfig()
         fnHash["type"] = static_cast<int>(func->type);
         fnHash["undefinedArgs"] = func->undefinedArgs;
         fnHash["allDatabases"] = func->allDatabases;
+        fnHash["deterministic"] = func->deterministic;
         list << fnHash;
     }
     CFG_CORE.Internal.Functions.set(list);
@@ -378,6 +379,7 @@ void FunctionManagerImpl::loadFromConfig()
         func->type = static_cast<ScriptFunction::Type>(fnHash["type"].toInt());
         func->undefinedArgs = fnHash["undefinedArgs"].toBool();
         func->allDatabases = fnHash["allDatabases"].toBool();
+        func->deterministic = fnHash["deterministic"].toBool();
         functions << func;
     }
 }

--- a/SQLiteStudio3/coreSQLiteStudio/services/impl/functionmanagerimpl.cpp
+++ b/SQLiteStudio3/coreSQLiteStudio/services/impl/functionmanagerimpl.cpp
@@ -338,8 +338,8 @@ void FunctionManagerImpl::refreshFunctionsByKey()
 
 void FunctionManagerImpl::storeInConfig()
 {
-    QVariantList list;
-    QHash<QString,QVariant> fnHash;
+    QList<QHash<QString, QVariant> > list;
+    QHash<QString, QVariant> fnHash;
     for (ScriptFunction* func : functions)
     {
         fnHash["name"] = func->name;
@@ -355,19 +355,18 @@ void FunctionManagerImpl::storeInConfig()
         fnHash["deterministic"] = func->deterministic;
         list << fnHash;
     }
-    CFG_CORE.Internal.Functions.set(list);
+    CFG->setScriptFunctions(list);
 }
 
 void FunctionManagerImpl::loadFromConfig()
 {
     clearFunctions();
 
-    QVariantList list = CFG_CORE.Internal.Functions.get();
-    QHash<QString,QVariant> fnHash;
+    QList<QHash<QString, QVariant> > list = CFG->getScriptFunctions();
+    QHash<QString, QVariant> fnHash;
     ScriptFunction* func = nullptr;
-    for (const QVariant& var : list)
+    for (const QHash<QString, QVariant>& fnHash : list)
     {
-        fnHash = var.toHash();
         func = new ScriptFunction();
         func->name = fnHash["name"].toString();
         func->lang = updateScriptingQtLang(fnHash["lang"].toString());


### PR DESCRIPTION
This is only a proof of concept patch, not sure if it's bug-free. If we store the functions as a normal table and not as QVariant default binary serialization format, it makes much easier to import and export them in bulk, using SQLiteStudio itself or external scripting.

It also fixes the `deterministic` function property not being persisted (#4848), but this fix can't be applied separately, or it would probably also need a database upgrade or some guard against missing hash key.

Related issues: #3531 #4014 #4848

Related discussions: #4797 #4205