### PR TITLE
GitHub Actions builds: Update to Qt 5.15.11, ICU 74.1 (Linux+Win), ICU 73.2 (Mac)

### DIFF
--- a/.github/workflows/lin_qt.yml
+++ b/.github/workflows/lin_qt.yml
@@ -30,7 +30,7 @@ jobs:
               #- "glibc_2.27"  # Ubuntu 18.04
               #- "glibc_2.31"  # Ubuntu 20.04, Debian 11
             version:
-              - "5.15.10"
+              - "5.15.11"
             include:
               - binary_compatibility: glibc_2.23
                 container: ghcr.io/${{ github.repository }}/gha-build-runner-xenial
@@ -101,14 +101,19 @@ jobs:
               run: |
                 set -x
                 cd qtbase-everywhere-src-${{ matrix.version }}
-                case ${{ matrix.version }} in 5.15.10)
-                    curl -L https://download.qt.io/official_releases/qt/5.15/CVE-2022-27404-27405-27406-qtbase-5.15.diff | patch -p1
-                    curl -L https://download.qt.io/official_releases/qt/5.15/CVE-2022-37434-qtbase-5.15.patch | patch -p1
+                case ${{ matrix.version }} in 5.15.11)
                     curl -L https://download.qt.io/official_releases/qt/5.15/CVE-2023-24607-qtbase-5.15.diff | patch -p1
                     curl -L https://download.qt.io/official_releases/qt/5.15/CVE-2023-32762-qtbase-5.15.diff | patch -p1
                     curl -L https://download.qt.io/official_releases/qt/5.15/CVE-2023-32763-qtbase-5.15.diff | patch -p1
                     curl -L https://download.qt.io/official_releases/qt/5.15/CVE-2023-33285-qtbase-5.15.diff | patch -p1
                     curl -L https://download.qt.io/official_releases/qt/5.15/CVE-2023-34410-qtbase-5.15.diff | patch -p1
+                    curl -L https://download.qt.io/official_releases/qt/5.15/CVE-2023-37369-qtbase-5.15.diff | patch -p1
+                    curl -L https://download.qt.io/official_releases/qt/5.15/CVE-2023-38197-qtbase-5.15.diff | patch -p1
+                    curl -L https://download.qt.io/official_releases/qt/5.15/CVE-2023-43114-5.15.patch | patch -p1
+
+                    cd ../qtimageformats-everywhere-src-${{ matrix.version }}
+                    curl -L https://download.qt.io/official_releases/qt/5.15/CVE-2023-4863-5.15.patch | patch -p1
+
                     cd ../qtsvg-everywhere-src-${{ matrix.version }}
                     curl -L https://download.qt.io/official_releases/qt/5.15/CVE-2023-32573-qtsvg-5.15.diff | patch -p1
                     ;;

--- a/.github/workflows/lin_release.yml
+++ b/.github/workflows/lin_release.yml
@@ -4,7 +4,7 @@ env:
     SQLITE_VERSION: '3410200'
     SQLITE_RELEASE_YEAR: '2023'
     PYTHON_VERSION: '3.9'
-    ICU_VERSION: '73.1'
+    ICU_VERSION: '74.1'
     PORTABLE_DIR: ${{ github.workspace }}/output/portable/SQLiteStudio
     INSTALLBUILDER_DIR: ../ib
     INSTALLBUILDER_URL: https://releases.installbuilder.com/installbuilder/installbuilder-enterprise-23.4.0-linux-x64-installer.run
@@ -37,12 +37,12 @@ jobs:
               #- "glibc_2.31"  # Ubuntu 20.04, Debian 11
             qt_version:
               - "5.15.2"
-              - "5.15.10"
+              - "5.15.11"
             exclude:
               - binary_compatibility: glibc_2.23
                 qt_version: "5.15.2"
               - binary_compatibility: glibc_2.27
-                qt_version: "5.15.10"
+                qt_version: "5.15.11"
             include:
               - binary_compatibility: glibc_2.23
                 container: ghcr.io/${{ github.repository }}/gha-build-runner-xenial
@@ -133,7 +133,7 @@ jobs:
 
             - name: Prepare ccache
               if: inputs.use_ccache || false
-              uses: hendrikmuhs/ccache-action@v1.2.8
+              uses: hendrikmuhs/ccache-action@v1.2
               with:
                 key: lin_release-${{ matrix.binary_compatibility }}
                 max-size: "24M"
@@ -258,8 +258,8 @@ jobs:
             - name: Copy Qt's libcrypto and libssl to portable dir (#4577)
               if: env.USE_PREBUILT_QT == 0
               run: |
-                wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.19_amd64.deb
-                dpkg-deb -xv libssl1.1_1.1.1f-1ubuntu2.19_amd64.deb .
+                wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.20_amd64.deb
+                dpkg-deb -xv libssl1.1_1.1.1f-1ubuntu2.20_amd64.deb .
                 cp ./usr/lib/$TARGET_ARCH-linux-gnu/libssl.so.1.1 ${{ env.PORTABLE_DIR }}/lib/
                 cp ./usr/lib/$TARGET_ARCH-linux-gnu/libcrypto.so.1.1 ${{ env.PORTABLE_DIR }}/lib/
 

--- a/.github/workflows/lin_runner.yml
+++ b/.github/workflows/lin_runner.yml
@@ -1,9 +1,9 @@
 name: "Linux build runner image"
 
 env:
-    icu_version: "73.1"
-    openssl_version: "1.1.1u"
-    python_version: "3.9.17"
+    icu_version: "74.1"
+    openssl_version: "1.1.1w"
+    python_version: "3.9.18"
     tcl_version: "8.6.13"
 
 on:

--- a/.github/workflows/mac_release.yml
+++ b/.github/workflows/mac_release.yml
@@ -4,7 +4,7 @@ env:
     SQLITE_VERSION: '3410200'
     SQLITE_RELEASE_YEAR: '2023'
     PYTHON_VERSION: '3.9'
-    ICU_VERSION: '73.1'
+    ICU_VERSION: '73.2'
     PORTABLE_DIR: ${{ github.workspace }}/output/portable/SQLiteStudio
     INSTALLBUILDER_DIR: ../ib
     INSTALLBUILDER_URL: https://releases.installbuilder.com/installbuilder/installbuilder-enterprise-23.4.0-osx-installer.dmg
@@ -40,72 +40,72 @@ jobs:
               # this list is meant to be synchronized with mac_universal_deps.yml
               - common_pkgs:
                   - brotli 1.0.9_2
-                  - dbus 1.14.6_0
+                  - dbus 1.14.10_0
                   - double-conversion 3.3.0_0
-                  - freetype 2.12.1_0
+                  - freetype 2.13.2_0
                   - gettext-runtime 0.21.1_0
                   - giflib 4.2.3_0
-                  - glib2 2.76.3_0+x11
+                  - glib2 2.78.0_0+x11
                   - graphite2 1.3.14_0
-                  - harfbuzz 6.0.0_1
-                  - icu 73.1_1
-                  - jasper 4.0.0_1
+                  - harfbuzz 8.3.0_0
+                  - icu 73.2_0
+                  - jasper 4.1.0_0
                   - lcms2 2.15_0
                   - lerc 4.0.0_1
-                  - libdeflate 1.18_0
-                  - libedit 20221030-3.1_0
+                  - libdeflate 1.19_0
+                  - libedit 20230828-3.1_0
                   - libffi 3.4.4_0
                   - libiconv 1.17_0
                   - libjpeg-turbo 2.1.5.1_0
                   - libmng 2.0.3_1
-                  - libpng 1.6.39_0
-                  - ncurses 6.4_0
-                  - openssl3 3.1.1_0
+                  - libpng 1.6.40_0
+                  - ncurses 6.4_1
+                  - openssl3 3.2.0_0
                   - pcre 8.45_0
                   - pcre2 10.42_0
-                  - python39 3.9.17_0+lto+optimizations
+                  - python39 3.9.18_0+lto+optimizations
                   - tcl 8.6.13_0+corefoundation+threads
-                  - tiff 4.5.1_1
-                  - webp 1.3.0_1
-                  - xz 5.4.3_0
+                  - tiff 4.6.0_0
+                  - webp 1.3.2_0
+                  - xz 5.4.5_0
                   - zstd 1.5.5_0
               - binary_compatibility: darwin_20.arm64-x86_64
                 cflags: -arch arm64 -arch x86_64
                 add_variants: "+universal"
                 dmg_postfix: "-macos11.universal"
-                qmake_flags: "QMAKE_APPLE_DEVICE_ARCHS=\"arm64 x86_64\""
                 pkgs:
-                  - qt5-qtbase 5.15.10_0+openssl
-                  - qt5-qtdeclarative 5.15.10_0
-                  - qt5-qtimageformats 5.15.10_0
-                  - qt5-qtscript 5.15.10_0
-                  - qt5-qtsvg 5.15.10_0
-                  - qt5-qttools 5.15.10_0
+                  - qt5-qtbase 5.15.11_0+openssl
+                  - qt5-qtdeclarative 5.15.11_0
+                  - qt5-qtimageformats 5.15.11_0
+                  - qt5-qtscript 5.15.11_0
+                  - qt5-qtsvg 5.15.11_0
+                  - qt5-qttools 5.15.11_0
+                qmake_flags: "QMAKE_APPLE_DEVICE_ARCHS=\"arm64 x86_64\""
               - binary_compatibility: darwin_17.x86_64
                 cflags: -arch x86_64
                 add_variants: ""
                 dmg_postfix: ""
-                qmake_flags: ""
                 pkgs:
-                  - qt5-qtbase 5.15.10_0+openssl
-                  - qt5-qtdeclarative 5.15.10_0
-                  - qt5-qtimageformats 5.15.10_0
-                  - qt5-qtscript 5.15.10_0
-                  - qt5-qtsvg 5.15.10_0
-                  - qt5-qttools 5.15.10_0
+                  - qt5-qtbase 5.15.11_0+openssl
+                  - qt5-qtdeclarative 5.15.11_0
+                  - qt5-qtimageformats 5.15.11_0
+                  - qt5-qtscript 5.15.11_0
+                  - qt5-qtsvg 5.15.11_0
+                  - qt5-qttools 5.15.11_0
+                qmake_flags: ""
               - binary_compatibility: darwin_16.x86_64
                 cflags: -arch x86_64
                 add_variants: ""
                 dmg_postfix: "-macos10.12"
-                qmake_flags: ""
                 pkgs:
-                  - legacy-support 1.0.10_0
+                  - legacy-support 1.1.1_0
                   - qt513-qtbase 5.13.2_9+openssl
                   - qt513-qtdeclarative 5.13.2_0
-                  - qt513-qtimageformats 5.13.2_2
+                  - qt513-qtimageformats 5.13.2_3
                   - qt513-qtscript 5.13.2_0
                   - qt513-qtsvg 5.13.2_0
                   - qt513-qttools 5.13.2_0
+                qmake_flags: ""
 
         steps:
             - name: Install the InstallBuilder

--- a/.github/workflows/mac_universal_deps.yml
+++ b/.github/workflows/mac_universal_deps.yml
@@ -30,47 +30,47 @@ jobs:
               # this list is meant to be synchronized with mac_release.yml
               - common_pkgs:
                   - brotli 1.0.9_2
-                  - dbus 1.14.6_0
+                  - dbus 1.14.10_0
                   - double-conversion 3.3.0_0
-                  - freetype 2.12.1_0
+                  - freetype 2.13.2_0
                   - gettext-runtime 0.21.1_0
                   - giflib 4.2.3_0
-                  - glib2 2.76.3_0+x11
+                  - glib2 2.78.0_0+x11
                   - graphite2 1.3.14_0
-                  - harfbuzz 6.0.0_1
-                  - icu 73.1_1
-                  - jasper 4.0.0_1
+                  - harfbuzz 8.3.0_0
+                  - icu 73.2_0
+                  - jasper 4.1.0_0
                   - lcms2 2.15_0
                   - lerc 4.0.0_1
-                  - libdeflate 1.18_0
-                  - libedit 20221030-3.1_0
+                  - libdeflate 1.19_0
+                  - libedit 20230828-3.1_0
                   - libffi 3.4.4_0
                   - libiconv 1.17_0
                   - libjpeg-turbo 2.1.5.1_0
                   - libmng 2.0.3_1
-                  - libpng 1.6.39_0
-                  - ncurses 6.4_0
-                  - openssl3 3.1.1_0
+                  - libpng 1.6.40_0
+                  - ncurses 6.4_1
+                  - openssl3 3.2.0_0
                   - pcre 8.45_0
                   - pcre2 10.42_0
-                  - python39 3.9.17_0+lto+optimizations
+                  - python39 3.9.18_0+lto+optimizations
                   - tcl 8.6.13_0+corefoundation+threads
-                  - tiff 4.5.1_1
-                  - webp 1.3.0_1
-                  - xz 5.4.3_0
+                  - tiff 4.6.0_0
+                  - webp 1.3.2_0
+                  - xz 5.4.5_0
                   - zstd 1.5.5_0
               - binary_compatibility: darwin_20.arm64-x86_64
                 cflags: -arch arm64 -arch x86_64
                 add_variants: "+universal"
                 dmg_postfix: "-macos11.universal"
-                qmake_flags: ""
                 pkgs:
-                  - qt5-qtbase 5.15.10_0+openssl
-                  - qt5-qtdeclarative 5.15.10_0
-                  - qt5-qtimageformats 5.15.10_0
-                  - qt5-qtscript 5.15.10_0
-                  - qt5-qtsvg 5.15.10_0
-                  - qt5-qttools 5.15.10_0
+                  - qt5-qtbase 5.15.11_0+openssl
+                  - qt5-qtdeclarative 5.15.11_0
+                  - qt5-qtimageformats 5.15.11_0
+                  - qt5-qtscript 5.15.11_0
+                  - qt5-qtsvg 5.15.11_0
+                  - qt5-qttools 5.15.11_0
+                qmake_flags: ""
 
         steps:
             - name: Restore distfiles packages cache
@@ -204,22 +204,33 @@ jobs:
                 set -x
 
                 # Try to install what's possible to install from binary packages
+                echo "::group::Installing $OUR_PYTHON"
                 sudo port -Nkv install "$OUR_PYTHON" +universal
                 sudo port -Nkv install python_select python3_select
                 sudo port select --set python "$OUR_PYTHON"
                 sudo port select --set python3 "$OUR_PYTHON"
+                echo "::endgroup::"
+
                 case "$MISSING_PACKAGES" in *glib2*)
+                    echo "::group::Installing glib2"
                     sudo port -Nkv install glib2 +universal  # our and cairo's dependency, needs +universal, +x11 is the default
+                    echo "::endgroup::"
                     ;;
                 esac
                 case "$MISSING_PACKAGES" in *harfbuzz*)
+                    echo "::group::Installing harfbuzz dependencies"
                     sudo port -Nk install python310  # fontconfig seems to need it badly but -universal is ok
                     sudo port -Nkv install cairo -x11 +universal  # skip x11 dependencies
+                    echo "::endgroup::"
                     ;;
                 esac
 
                 _the_rest="$(echo "$MISSING_PACKAGES" | grep -v '^qt5-')"
-                [ -z "$_the_rest" ] || sudo port -Nkv install $_the_rest
+                [ -z "$_the_rest" ] || {
+                    echo "::group::Installing $_the_rest"
+                    sudo port -Nkv install $_the_rest
+                    echo "::endgroup::"
+                }
 
             - name: Install missing Qt packages except qt5-qttools
               if: env.MISSING_PACKAGES != ''

--- a/.github/workflows/win32_release.yml
+++ b/.github/workflows/win32_release.yml
@@ -2,8 +2,8 @@ env:
     SQLITE_VERSION: '3410200'
     SQLITE_RELEASE_YEAR: '2023'
     PYTHON_VERSION: '3.9'
-    ICU_VER: '72'
-    ICU_URL: https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-icu-72.1-1-any.pkg.tar.zst
+    ICU_VER: '74'
+    ICU_URL: https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-icu-74.1-1-any.pkg.tar.zst
     PORTABLE_DIR: output/portable/SQLiteStudio
     INSTALLBUILDER_DIR: ../ib
     MINGW_URL: https://download.qt.io/online/qtsdkrepository/windows_x86/desktop/tools_mingw/qt.tools.win32_mingw810/8.1.0-1-202004170606i686-8.1.0-release-posix-dwarf-rt_v6-rev0.7z
@@ -32,7 +32,7 @@ jobs:
           matrix:
             qt_version:
               - "5.15.2"
-              - "5.15.10"
+              - "5.15.11"
 
         steps:
             - name: Configure environment
@@ -144,7 +144,7 @@ jobs:
 
             - name: Prepare ccache using action
               if: inputs.use_ccache || false
-              uses: hendrikmuhs/ccache-action@v1.2.9
+              uses: hendrikmuhs/ccache-action@v1.2
               with:
                 key: win32-qt${{ matrix.qt_version }}-release
                 max-size: "24M"

--- a/.github/workflows/win64_release.yml
+++ b/.github/workflows/win64_release.yml
@@ -2,8 +2,8 @@ env:
     SQLITE_VERSION: '3410200'
     SQLITE_RELEASE_YEAR: '2023'
     PYTHON_VERSION: '3.9'
-    ICU_VER: '72'
-    ICU_URL: https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-icu-72.1-1-any.pkg.tar.zst
+    ICU_VER: '74'
+    ICU_URL: https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-icu-74.1-1-any.pkg.tar.zst
     MINGW_DIR: ../Qt/Tools/mingw810_64
     PORTABLE_DIR: output/portable/SQLiteStudio
     INSTALLBUILDER_DIR: ../ib
@@ -33,7 +33,7 @@ jobs:
           matrix:
             qt_version:
               - "5.15.2"
-              - "5.15.10"
+              - "5.15.11"
 
         steps:
             - name: Configure environment
@@ -146,7 +146,7 @@ jobs:
 
             - name: Prepare ccache using action
               if: inputs.use_ccache || false
-              uses: hendrikmuhs/ccache-action@v1.2.9
+              uses: hendrikmuhs/ccache-action@v1.2
               with:
                 key: win64-qt${{ matrix.qt_version }}-release
                 max-size: "24M"


### PR DESCRIPTION
This PR updates the Actions workflows dependencies.
As usual, `lin_runner.yml` needs to be run once, manually.