### PR TITLE
GitHub Actions Linux build fixes

### DIFF
--- a/.github/workflows/lin_qt.yml
+++ b/.github/workflows/lin_qt.yml
@@ -29,7 +29,7 @@ jobs:
               #- "glibc_2.27"  # Ubuntu 18.04
               #- "glibc_2.31"  # Ubuntu 20.04, Debian 11
             version:
-              - "5.15.12"
+              - "5.15.13"
             include:
               - binary_compatibility: glibc_2.23
                 container: ghcr.io/${{ github.repository }}/gha-build-runner-xenial
@@ -107,8 +107,7 @@ jobs:
               run: |
                 set -x
                 cd qtbase-everywhere-src-${{ matrix.version }}
-                case ${{ matrix.version }} in 5.15.12)
-                    curl -L https://download.qt.io/official_releases/qt/5.15/CVE-2023-24607-qtbase-5.15.diff | patch -p1
+                case ${{ matrix.version }} in 5.15.13)
                     curl -L https://download.qt.io/official_releases/qt/5.15/CVE-2023-32762-qtbase-5.15.diff | patch -p1
                     curl -L https://download.qt.io/official_releases/qt/5.15/CVE-2023-32763-qtbase-5.15.diff | patch -p1
                     curl -L https://download.qt.io/official_releases/qt/5.15/CVE-2023-33285-qtbase-5.15.diff | patch -p1
@@ -118,9 +117,7 @@ jobs:
                     curl -L https://download.qt.io/official_releases/qt/5.15/CVE-2023-43114-5.15.patch | patch -p1
                     curl -L https://download.qt.io/official_releases/qt/5.15/0001-CVE-2023-51714-qtbase-5.15.diff | patch -p1
                     curl -L https://download.qt.io/official_releases/qt/5.15/0002-CVE-2023-51714-qtbase-5.15.diff | patch -p1
-
-                    cd ../qtimageformats-everywhere-src-${{ matrix.version }}
-                    curl -L https://download.qt.io/official_releases/qt/5.15/CVE-2023-4863-5.15.patch | patch -p1
+                    curl -L https://download.qt.io/official_releases/qt/5.15/CVE-2024-25580-qtbase-5.15.diff | patch -p1
 
                     cd ../qtsvg-everywhere-src-${{ matrix.version }}
                     curl -L https://download.qt.io/official_releases/qt/5.15/CVE-2023-32573-qtsvg-5.15.diff | patch -p1

--- a/.github/workflows/lin_qt.yml
+++ b/.github/workflows/lin_qt.yml
@@ -2,7 +2,7 @@ name: "Linux dependencies: Qt"
 
 env:
     workflow_name: lin_qt
-    submodules: qtdeclarative qtimageformats qtsvg qttools qtx11extras
+    submodules: qtdeclarative qtimageformats qtsvg qttools qtwayland qtx11extras
     TARGET_ARCH: "x86_64"
 
 on:
@@ -72,6 +72,7 @@ jobs:
                     libgtk-3-dev \
                     libsqlite3-dev \
                     libsm-dev \
+                    libwayland-dev \
                     libx11-dev \
                     libx11-xcb-dev \
                     libxext-dev \

--- a/.github/workflows/lin_qt.yml
+++ b/.github/workflows/lin_qt.yml
@@ -20,7 +20,6 @@ on:
 jobs:
     build:
         runs-on: ubuntu-latest
-        container: ${{ matrix.container }}
 
         strategy:
           fail-fast: false
@@ -42,17 +41,24 @@ jobs:
         steps:
             - name: Prepare ccache
               if: inputs.use_ccache || false
-              uses: hendrikmuhs/ccache-action@v1.2.8
+              uses: hendrikmuhs/ccache-action@v1.2
               with:
                 key: ${{ env.workflow_name }}-${{ matrix.version }}-${{ matrix.binary_compatibility }}
-                max-size: "712M"
+                max-size: "100M"
 
-            - name: Configure ccache
-              if: inputs.use_ccache || false
+            - name: Prepare build container
+              uses: actionsh/docker-shell-action@v0
+              with:
+                image: '${{ matrix.container }}'
+
+            - name: Configure build container
+              shell: docker-shell {0}
               run: |
-                echo "PATH=/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH" >> $GITHUB_ENV
+                [ ${{ inputs.use_ccache || false }} != true ] || \
+                  echo '/usr/lib/ccache:/usr/local/opt/ccache/libexec' >> "$GITHUB_PATH"
 
             - name: Install software build dependencies
+              shell: docker-shell {0}
               run: |
                 sudo apt-get -y install \
                     libatspi2.0-dev \
@@ -122,10 +128,11 @@ jobs:
                 esac
 
             - name: Configure qtbase
+              shell: docker-shell {0}
               run: |
                 cd qtbase-everywhere-src-${{ matrix.version }}
                 if [ ${{ inputs.use_ccache || false }} = true ]; then
-                    ADD_CONFIGURE_FLAGS="-ccache"
+                    ADD_CONFIGURE_FLAGS="-ccache -no-pch"
                 fi
                 OPENSSL_LIBS="-L/usr/local/lib -lssl -lcrypto" ./configure \
                     -I /usr/local/include \
@@ -161,6 +168,7 @@ jobs:
                     -xkbcommon
 
             - name: Build qtbase
+              shell: docker-shell {0}
               run: |
                 set -x
                 cd qtbase-everywhere-src-${{ matrix.version }}
@@ -169,6 +177,7 @@ jobs:
                 sudo make install  # for submodules build
 
             - name: Build submodules
+              shell: docker-shell {0}
               run: |
                 set -x
                 for _m in $submodules; do
@@ -181,9 +190,9 @@ jobs:
 
             - name: Create package
               run: |
-                set -x
+                set -ex
                 _pkgfile="qt5-${{ matrix.version }}-${{ matrix.binary_compatibility }}.$TARGET_ARCH.tar.zst"
-                (cd /tmp/stage; tar -c *) | zstd -9 > $_pkgfile
+                echo 'cd /tmp/stage; tar -c *' | docker-shell | zstd -9 > $_pkgfile
                 echo "SOFTWARE_PACKAGE_FILE=$_pkgfile" >> $GITHUB_ENV
 
             - name: Upload package artifact

--- a/.github/workflows/lin_release.yml
+++ b/.github/workflows/lin_release.yml
@@ -1,4 +1,5 @@
 env:
+    workflow_name: lin_release
     TARGET_ARCH: 'x86_64'
     TCL_VERSION: '8.6.13'
     SQLITE_VERSION: '3410200'
@@ -7,7 +8,7 @@ env:
     ICU_VERSION: '74.1'
     PORTABLE_DIR: ${{ github.workspace }}/output/portable/SQLiteStudio
     INSTALLBUILDER_DIR: ../ib
-    INSTALLBUILDER_URL: https://releases.installbuilder.com/installbuilder/installbuilder-enterprise-23.4.0-linux-x64-installer.run
+    INSTALLBUILDER_URL: https://releases.installbuilder.com/installbuilder/installbuilder-enterprise-24.3.0-linux-x64-installer.run
 
 name: Linux release build
 
@@ -26,7 +27,6 @@ on:
 jobs:
     build:
         runs-on: ubuntu-latest
-        container: ${{ matrix.container }}
 
         strategy:
           fail-fast: false
@@ -87,18 +87,32 @@ jobs:
                 py7zrversion: '==0.20.*'
                 setup-python: 'false'
 
-            - name: Install apt dependencies for prebuilt Qt
-              if: env.USE_PREBUILT_QT == 1
+            - name: Clone repo
+              uses: actions/checkout@v4
+              with:
+                ref: ${{ github.event.client_payload.branch }}
+
+            - name: Prepare ccache
+              if: inputs.use_ccache || false
+              uses: hendrikmuhs/ccache-action@v1.2
+              with:
+                key: ${{ env.workflow_name }}-${{ matrix.binary_compatibility }}
+                max-size: "24M"
+
+            - name: Prepare build container
+              uses: actionsh/docker-shell-action@v0
+              with:
+                image: '${{ matrix.container }}'
+
+            - name: Configure build container
+              shell: docker-shell {0}
               run: |
-                sudo apt-get -y install \
-                    libgl1-mesa-dev \
-                    libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 \
-                    libxcb-render-util0 libxcb-xinerama0 libxcb-xkb1 \
-                    libxkbcommon0 libxkbcommon-x11-0
+                [ ${{ inputs.use_ccache || false }} != true ] || \
+                  echo '/usr/lib/ccache:/usr/local/opt/ccache/libexec' >> "$GITHUB_PATH"
 
             - name: Download prebuilt Qt
               if: env.USE_PREBUILT_QT == 1
-              uses: dawidd6/action-download-artifact@v2
+              uses: dawidd6/action-download-artifact@v3
               with:
                 workflow: lin_qt.yml
                 workflow_conclusion: success
@@ -107,11 +121,11 @@ jobs:
             - name: Install prebuilt Qt
               if: env.USE_PREBUILT_QT == 1
               run: |
-                zstdcat qt5-*.tar.zst | tar -C / -xv
+                zstdcat qt5-*.tar.zst | docker-shell -c 'sudo tar -C / -xv'
                 echo "Qt5_Dir=/usr/local" >> $GITHUB_ENV
 
             - name: Install the InstalBuilder
-              shell: bash
+              shell: docker-shell {0}
               run: |
                 curl -L ${{ env.INSTALLBUILDER_URL }} --output ib.run
                 chmod +x ib.run
@@ -120,30 +134,14 @@ jobs:
                 echo "INSTALLER_SRC_PREFIX=$(pwd)" >> $GITHUB_ENV
                 echo "INSTALLER_BIN_PREFIX=${{ env.PORTABLE_DIR }}" >> $GITHUB_ENV
 
-            - name: Clone repo
-              uses: actions/checkout@v3
-              with:
-                ref: ${{ github.event.client_payload.branch }}
-
             - name: Pre-download SQLite vanilla sourcecode
               shell: bash
               run: |
                 cd ..
                 curl -L http://sqlite.org/$SQLITE_RELEASE_YEAR/sqlite-src-$SQLITE_VERSION.zip --output sqlite-src-$SQLITE_VERSION.zip
 
-            - name: Prepare ccache
-              if: inputs.use_ccache || false
-              uses: hendrikmuhs/ccache-action@v1.2
-              with:
-                key: lin_release-${{ matrix.binary_compatibility }}
-                max-size: "24M"
-
-            - name: Configure ccache
-              if: inputs.use_ccache || false
-              run: |
-                echo "PATH=/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH" >> $GITHUB_ENV
-
             - name: Install SQLite3
+              shell: docker-shell {0}
               run: |
                 sudo rm -f /usr/lib/libsqlite* /usr/local/lib/libsqlite* /usr/include/sqlite* /usr/local/include/sqlite* /usr/lib/$TARGET_ARCH-linux-gnu/libsqlite*
                 wget http://sqlite.org/$SQLITE_RELEASE_YEAR/sqlite-amalgamation-$SQLITE_VERSION.zip
@@ -167,6 +165,7 @@ jobs:
                 sudo cp *.h /usr/local/include/
 
             - name: Install extension dependencies
+              shell: docker-shell {0}
               run: |
                 if [ "$USE_PREBUILT_QT" = 0 ]; then
                     sudo apt-get -y install libicu-dev libicu${{ matrix.icu_version_short }}
@@ -174,7 +173,7 @@ jobs:
                 sudo apt-get -y install zlib1g-dev
 
             - name: Compile additional SQLite3 extensions
-              shell: bash
+              shell: docker-shell {0}
               run: |
                 cd ..
                 mkdir ext
@@ -190,12 +189,14 @@ jobs:
                     gcc misc/$f.c $FLAGS -o ../../ext/$f.so
                 done
                 for f in icu; do
-                    echo "gcc icu/$f.c $FLAGS $(pkg-config --libs --cflags icu-uc icu-io) -o ../../ext/$f.so"
-                    gcc icu/$f.c $FLAGS `pkg-config --libs --cflags icu-uc icu-io` -o ../../ext/$f.so
+                    ICU_FLAGS="$(pkg-config --libs --cflags icu-uc icu-io)"
+                    echo "gcc icu/$f.c $ICU_FLAGS $FLAGS -o ../../ext/$f.so"
+                    gcc icu/$f.c $ICU_FLAGS $FLAGS -o ../../ext/$f.so
                 done
                 ls -l ../../ext/
 
             - name: Install other tools/dependencies
+              shell: docker-shell {0}
               run: |
                 sudo apt install -y libreadline-dev libncurses5-dev patchelf chrpath
                 if [ $USE_PREBUILT_QT = 0 ]; then
@@ -206,6 +207,7 @@ jobs:
               run: mkdir output output/build output/build/Plugins
 
             - name: Compile SQLiteStudio3
+              shell: docker-shell {0}
               working-directory: output/build
               run: |
                 qmake \
@@ -215,6 +217,7 @@ jobs:
                 make -j $(nproc)
 
             - name: Compile Plugins
+              shell: docker-shell {0}
               working-directory: output/build/Plugins
               run: |
                 qmake \
@@ -235,14 +238,13 @@ jobs:
                 mkdir portable
                 cp -R SQLiteStudio portable/
 
-                # Update PORTABLE_DIR since we're in a container
-                echo "PORTABLE_DIR=$(cd portable/SQLiteStudio; pwd -P)" >> $GITHUB_ENV
-
             - name: Copy SQLite3 to portable dir
+              shell: docker-shell {0}
               working-directory: ${{ env.PORTABLE_DIR }}
               run: cp -P /usr/local/lib/libsqlite3.so* lib/
 
             - name: Copy SQLCipher's libcrypto to portable dir
+              shell: docker-shell {0}
               working-directory: ${{ env.PORTABLE_DIR }}
               run: |
                 LIBCRYPTO=$(ldd plugins/libDbSqliteCipher.so | grep crypto | awk '{print $3}')
@@ -251,6 +253,7 @@ jobs:
 
             - name: Copy prebuilt OpenSSL to portable dir
               if: env.USE_PREBUILT_QT == 1
+              shell: docker-shell {0}
               working-directory: /usr/local/lib
               run: |
                 cp libssl.so.1.1 libcrypto.so.1.1 $PORTABLE_DIR/lib/
@@ -258,12 +261,13 @@ jobs:
             - name: Copy Qt's libcrypto and libssl to portable dir (#4577)
               if: env.USE_PREBUILT_QT == 0
               run: |
-                wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.20_amd64.deb
-                dpkg-deb -xv libssl1.1_1.1.1f-1ubuntu2.20_amd64.deb .
+                wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.22_amd64.deb
+                dpkg-deb -xv libssl1.1_1.1.1f-1ubuntu2.22_amd64.deb .
                 cp ./usr/lib/$TARGET_ARCH-linux-gnu/libssl.so.1.1 ${{ env.PORTABLE_DIR }}/lib/
                 cp ./usr/lib/$TARGET_ARCH-linux-gnu/libcrypto.so.1.1 ${{ env.PORTABLE_DIR }}/lib/
 
             - name: Copy Qt to portable dir
+              shell: docker-shell {0}
               working-directory: ${{ env.PORTABLE_DIR }}
               run: |
                 cp -P ${{ env.Qt5_Dir }}/lib/libQt5Core.so* lib/
@@ -282,6 +286,7 @@ jobs:
                 cp -P ${{ env.Qt5_Dir }}/lib/libicudata.so.$ICU_VERSION_SHORT* lib/
 
             - name: Copy Qt plugins to portable dir
+              shell: docker-shell {0}
               working-directory: ${{ env.PORTABLE_DIR }}
               run: |
                 mkdir platforms imageformats iconengines printsupport platformthemes platforminputcontexts
@@ -299,6 +304,7 @@ jobs:
                 cp -P ${{ env.Qt5_Dir }}/plugins/platforminputcontexts/libcomposeplatforminputcontextplugin.so platforminputcontexts/libcomposeplatforminputcontextplugin.so
 
             - name: Copy extra Qt dependencies to portable dir
+              shell: docker-shell {0}
               working-directory: ${{ env.PORTABLE_DIR }}
               run: |
                 libdir=/usr/lib/$TARGET_ARCH-linux-gnu
@@ -311,13 +317,13 @@ jobs:
                     cp -P $libdir/libxcb-render-util.so* lib/
                     cp -P $libdir/libxcb-xinerama.so* lib/
                     # These are not installed by default on my Xubuntu 22.04:
-                    if [ "$USE_PREBUILT_QT" = 0 ]; then apt-get install -y libxkbcommon-x11-0; fi
                     cp -P $libdir/libxcb-xkb.so* lib/
                     cp -P $libdir/libxkbcommon.so* lib/      # libxkbcommon _is_ installed by default but must match the version of
                     cp -P $libdir/libxkbcommon-x11.so* lib/  # libxkbcommon-x11 which is not
                 fi
 
             - name: Fix dependency paths
+              shell: docker-shell {0}
               working-directory: ${{ env.PORTABLE_DIR }}
               run: |
                 chrpath -k -r \$ORIGIN/../lib   platforms/*.so imageformats/*.so iconengines/*.so printsupport/*.so platformthemes/*.so plugins/*.so 2>&1 >/dev/null
@@ -329,13 +335,14 @@ jobs:
                 chrpath -l sqlitestudio
                 chrpath -l sqlitestudiocli
 
-            - name: Final preparations for packaging
+            - name: Final preparations for packaging, copying app icon assets
               run: |
                 mkdir "${{ env.PORTABLE_DIR }}"/assets
                 cp SQLiteStudio3/guiSQLiteStudio/img/sqlitestudio_256.png "${{ env.PORTABLE_DIR }}"/assets/appicon.png
                 cp SQLiteStudio3/guiSQLiteStudio/img/sqlitestudio.svg "${{ env.PORTABLE_DIR }}"/assets/appicon.svg
 
             - name: Final preparations for packaging
+              shell: docker-shell {0}
               working-directory: ${{ env.PORTABLE_DIR }}
               run: |
                 cp `ldd sqlitestudiocli | grep readline | awk '{print $3}'` lib/
@@ -346,6 +353,7 @@ jobs:
                 patchelf --set-rpath '$ORIGIN' lib/libreadline*
 
             - name: Determine SQLiteStudio version
+              shell: docker-shell {0}
               working-directory: ${{ env.PORTABLE_DIR }}
               run: |
                 SQLITESTUDIO_VERSION="$(./sqlitestudiocli --version | cut -f 2 -d ' ')"
@@ -362,7 +370,7 @@ jobs:
                 ls -l
 
             - name: Create installer package
-              shell: bash
+              shell: docker-shell {0}
               env:
                 IB_LICENSE: ${{ secrets.INSTALLER_LICENSE }}
               run: |

--- a/.github/workflows/lin_release.yml
+++ b/.github/workflows/lin_release.yml
@@ -243,6 +243,13 @@ jobs:
               working-directory: ${{ env.PORTABLE_DIR }}
               run: cp -P /usr/local/lib/libsqlite3.so* lib/
 
+            - name: Copy libtcl to portable dir
+              shell: docker-shell {0}
+              working-directory: ${{ env.PORTABLE_DIR }}
+              run: |
+                cp -P "/usr/local/lib/libtcl$TCL_VERSION_SHORT.so" lib/
+                chmod u+w "lib/libtcl$TCL_VERSION_SHORT.so"
+
             - name: Copy SQLCipher's libcrypto to portable dir
               shell: docker-shell {0}
               working-directory: ${{ env.PORTABLE_DIR }}
@@ -336,12 +343,12 @@ jobs:
               run: |
                 set -x
                 chrpath -k -r \$ORIGIN/../lib   platforms/*.so imageformats/*.so iconengines/*.so printsupport/*.so platformthemes/*.so plugins/*.so
-                chrpath -k -r \$ORIGIN          lib/libicu*.*.*
+                chrpath -k -r \$ORIGIN          lib/libicu*.*.* lib/libtcl$TCL_VERSION_SHORT.so
                 chrpath -k -r \$ORIGIN          lib/libcoreSQLiteStudio.so lib/libguiSQLiteStudio.so
                 chrpath -k -r \$ORIGIN/lib      sqlitestudio
                 chrpath -k -r \$ORIGIN/lib      sqlitestudiocli
                 chrpath -l platforms/*.so imageformats/*.so iconengines/*.so printsupport/*.so platformthemes/*.so plugins/*.so
-                chrpath -l lib/libicu*.*.*
+                chrpath -l lib/libicu*.*.* lib/libtcl$TCL_VERSION_SHORT.so
                 chrpath -l lib/libcoreSQLiteStudio.so lib/libguiSQLiteStudio.so
                 chrpath -l sqlitestudio
                 chrpath -l sqlitestudiocli

--- a/.github/workflows/lin_release.yml
+++ b/.github/workflows/lin_release.yml
@@ -277,6 +277,7 @@ jobs:
                 cp -P ${{ env.Qt5_Dir }}/lib/libQt5Network.so* lib/
                 cp -P ${{ env.Qt5_Dir }}/lib/libQt5PrintSupport.so* lib/
                 cp -P ${{ env.Qt5_Dir }}/lib/libQt5Qml.so* lib/
+                cp -P ${{ env.Qt5_Dir }}/lib/libQt5WaylandClient.so* lib/
                 cp -P ${{ env.Qt5_Dir }}/lib/libQt5Widgets.so* lib/
                 cp -P ${{ env.Qt5_Dir }}/lib/libQt5Xml.so* lib/
                 cp -P ${{ env.Qt5_Dir }}/lib/libQt5Svg.so* lib/
@@ -290,6 +291,7 @@ jobs:
               working-directory: ${{ env.PORTABLE_DIR }}
               run: |
                 mkdir platforms imageformats iconengines printsupport platformthemes platforminputcontexts
+                cp -P ${{ env.Qt5_Dir }}/plugins/platforms/libqwayland-generic.so platforms/libqwayland-generic.so
                 cp -P ${{ env.Qt5_Dir }}/plugins/platforms/libqxcb.so platforms/libqxcb.so
                 cp -P ${{ env.Qt5_Dir }}/plugins/imageformats/libqgif.so imageformats/libqgif.so
                 cp -P ${{ env.Qt5_Dir }}/plugins/imageformats/libqicns.so imageformats/libqicns.so
@@ -321,16 +323,25 @@ jobs:
                     cp -P $libdir/libxkbcommon.so* lib/      # libxkbcommon _is_ installed by default but must match the version of
                     cp -P $libdir/libxkbcommon-x11.so* lib/  # libxkbcommon-x11 which is not
                 fi
+                if ldd lib/libQt5WaylandClient.so | grep -q libwayland-; then
+                    # These must probably match the build system
+                    cp -P $libdir/libwayland-client.so* lib/
+                    cp -P $libdir/libwayland-cursor.so* lib/
+                    cp -P $libdir/libffi.so* lib/
+                fi
 
             - name: Fix dependency paths
               shell: docker-shell {0}
               working-directory: ${{ env.PORTABLE_DIR }}
               run: |
-                chrpath -k -r \$ORIGIN/../lib   platforms/*.so imageformats/*.so iconengines/*.so printsupport/*.so platformthemes/*.so plugins/*.so 2>&1 >/dev/null
-                chrpath -k -r \$ORIGIN          lib/libcoreSQLiteStudio.so lib/libguiSQLiteStudio.so 2>&1 >/dev/null
-                chrpath -k -r \$ORIGIN/lib      sqlitestudio 2>&1 >/dev/null
-                chrpath -k -r \$ORIGIN/lib      sqlitestudiocli 2>&1 >/dev/null
+                set -x
+                chrpath -k -r \$ORIGIN/../lib   platforms/*.so imageformats/*.so iconengines/*.so printsupport/*.so platformthemes/*.so plugins/*.so
+                chrpath -k -r \$ORIGIN          lib/libicu*.*.*
+                chrpath -k -r \$ORIGIN          lib/libcoreSQLiteStudio.so lib/libguiSQLiteStudio.so
+                chrpath -k -r \$ORIGIN/lib      sqlitestudio
+                chrpath -k -r \$ORIGIN/lib      sqlitestudiocli
                 chrpath -l platforms/*.so imageformats/*.so iconengines/*.so printsupport/*.so platformthemes/*.so plugins/*.so
+                chrpath -l lib/libicu*.*.*
                 chrpath -l lib/libcoreSQLiteStudio.so lib/libguiSQLiteStudio.so
                 chrpath -l sqlitestudio
                 chrpath -l sqlitestudiocli
@@ -350,7 +361,11 @@ jobs:
 
                 # strip does not like binaries processed by patchelf, so strip first
                 strip lib/*.so sqlitestudio sqlitestudiocli platforms/*.so imageformats/*.so iconengines/*.so printsupport/*.so platformthemes/*.so plugins/*.so
-                patchelf --set-rpath '$ORIGIN' lib/libreadline*
+                # These may have no initial rpath/runpath so chrpath does not work on them
+                patchelf --set-rpath '$ORIGIN' \
+                  lib/libQt5Core.so.*.*.* \
+                  lib/libreadline* \
+                  lib/libwayland-c*.so.*.*.*
 
             - name: Determine SQLiteStudio version
               shell: docker-shell {0}

--- a/.github/workflows/lin_release.yml
+++ b/.github/workflows/lin_release.yml
@@ -1,11 +1,11 @@
 env:
     workflow_name: lin_release
     TARGET_ARCH: 'x86_64'
-    TCL_VERSION: '8.6.13'
+    TCL_VERSION: '8.6.14'
     SQLITE_VERSION: '3410200'
     SQLITE_RELEASE_YEAR: '2023'
     PYTHON_VERSION: '3.9'
-    ICU_VERSION: '74.1'
+    ICU_VERSION: '74.2'
     PORTABLE_DIR: ${{ github.workspace }}/output/portable/SQLiteStudio
     INSTALLBUILDER_DIR: ../ib
     INSTALLBUILDER_URL: https://releases.installbuilder.com/installbuilder/installbuilder-enterprise-24.3.0-linux-x64-installer.run
@@ -37,12 +37,12 @@ jobs:
               #- "glibc_2.31"  # Ubuntu 20.04, Debian 11
             qt_version:
               - "5.15.2"
-              - "5.15.12"
+              - "5.15.13"
             exclude:
               - binary_compatibility: glibc_2.23
                 qt_version: "5.15.2"
               - binary_compatibility: glibc_2.27
-                qt_version: "5.15.12"
+                qt_version: "5.15.13"
             include:
               - binary_compatibility: glibc_2.23
                 container: ghcr.io/${{ github.repository }}/gha-build-runner-xenial

--- a/.github/workflows/lin_runner.yml
+++ b/.github/workflows/lin_runner.yml
@@ -1,10 +1,10 @@
 name: "Linux build runner image"
 
 env:
-    icu_version: "74.1"
+    icu_version: "74.2"
     openssl_version: "1.1.1w"
-    python_version: "3.9.18"
-    tcl_version: "8.6.13"
+    python_version: "3.9.19"
+    tcl_version: "8.6.14"
 
 on:
     workflow_dispatch:

--- a/.github/workflows/lin_runner.yml
+++ b/.github/workflows/lin_runner.yml
@@ -80,6 +80,7 @@ jobs:
                 # Install Qt runtime deps here
                 RUN apt-get -y install \
                     libgl1-mesa-dev \
+                    libwayland-client0 libwayland-cursor0 \
                     libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 \
                     libxcb-render-util0 libxcb-xinerama0 libxcb-xkb1 \
                     libxkbcommon0 libxkbcommon-x11-0

--- a/.github/workflows/lin_runner.yml
+++ b/.github/workflows/lin_runner.yml
@@ -77,6 +77,12 @@ jobs:
                     && make -j$(nproc) && make install \
                     && ln -sf tclsh${tcl_version%.*} /usr/local/bin/tclsh \
                     && cd ../.. && rm -fr tcl${{ env.tcl_version }}
+                # Install Qt runtime deps here
+                RUN apt-get -y install \
+                    libgl1-mesa-dev \
+                    libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 \
+                    libxcb-render-util0 libxcb-xinerama0 libxcb-xkb1 \
+                    libxkbcommon0 libxkbcommon-x11-0
                 EOF_Dockerfile
 
             - name: Build and publish


### PR DESCRIPTION
* Due to actions/runner#2906, we can no longer run the whole workflow job in our container. Fix this by running the container in the background using [actionsh/docker-shell-action](https://github.com/actionsh/docker-shell-action) and then running only the relevant shell steps in the container.
* Update to the latest stable dependencies.
* Fix missing libtcl.
* Include qt5-qtwayland to fix AlmaLinux 9.3 segfaulting. Running with QT_QPA_PLATFORM=wayland still does not work properly, but XWayland fallback is working when QT_QPA_PLATFORM is not specified.