### PR TITLE
Linux build: Update Qt to 5.5.14, OpenSSL to 3.0.14

### DIFF
--- a/.github/workflows/lin_qt.yml
+++ b/.github/workflows/lin_qt.yml
@@ -29,7 +29,7 @@ jobs:
               #- "glibc_2.27"  # Ubuntu 18.04
               #- "glibc_2.31"  # Ubuntu 20.04, Debian 11
             version:
-              - "5.15.13"
+              - "5.15.14"
             include:
               - binary_compatibility: glibc_2.23
                 container: ghcr.io/${{ github.repository }}/gha-build-runner-xenial
@@ -108,10 +108,8 @@ jobs:
               run: |
                 set -x
                 cd qtbase-everywhere-src-${{ matrix.version }}
-                case ${{ matrix.version }} in 5.15.13)
-                    curl -L https://download.qt.io/official_releases/qt/5.15/CVE-2023-32762-qtbase-5.15.diff | patch -p1
+                case ${{ matrix.version }} in 5.15.14)
                     curl -L https://download.qt.io/official_releases/qt/5.15/CVE-2023-32763-qtbase-5.15.diff | patch -p1
-                    curl -L https://download.qt.io/official_releases/qt/5.15/CVE-2023-33285-qtbase-5.15.diff | patch -p1
                     curl -L https://download.qt.io/official_releases/qt/5.15/CVE-2023-34410-qtbase-5.15.diff | patch -p1
                     curl -L https://download.qt.io/official_releases/qt/5.15/CVE-2023-37369-qtbase-5.15.diff | patch -p1
                     curl -L https://download.qt.io/official_releases/qt/5.15/CVE-2023-38197-qtbase-5.15.diff | patch -p1
@@ -119,9 +117,6 @@ jobs:
                     curl -L https://download.qt.io/official_releases/qt/5.15/0001-CVE-2023-51714-qtbase-5.15.diff | patch -p1
                     curl -L https://download.qt.io/official_releases/qt/5.15/0002-CVE-2023-51714-qtbase-5.15.diff | patch -p1
                     curl -L https://download.qt.io/official_releases/qt/5.15/CVE-2024-25580-qtbase-5.15.diff | patch -p1
-
-                    cd ../qtsvg-everywhere-src-${{ matrix.version }}
-                    curl -L https://download.qt.io/official_releases/qt/5.15/CVE-2023-32573-qtsvg-5.15.diff | patch -p1
                     ;;
                 esac
 
@@ -132,12 +127,15 @@ jobs:
                 if [ ${{ inputs.use_ccache || false }} = true ]; then
                     ADD_CONFIGURE_FLAGS="-ccache -no-pch"
                 fi
+                sudo apt-get -y remove openssl openssl-dev || true
+                ls -l /usr/lib/libssl* /usr/lib/libcrypto* /usr/lib64/libssl* /usr/lib64/libcrypto* || true
+                sudo rm -fr /usr/lib/libssl* /usr/lib/libcrypto* /usr/lib64/libssl* /usr/lib64/libcrypto*
                 OPENSSL_LIBS="-L/usr/local/lib -lssl -lcrypto" ./configure \
                     -I /usr/local/include \
                     -L /usr/local/lib \
                     -appstore-compliant \
                     -bundled-xcb-xinput \
-                    $ADD_CONFIGURE_FLAGS \
+                    ${ADD_CONFIGURE_FLAGS:-} \
                     -confirm-license \
                     -dbus-runtime \
                     -fontconfig \

--- a/.github/workflows/lin_release.yml
+++ b/.github/workflows/lin_release.yml
@@ -37,12 +37,12 @@ jobs:
               #- "glibc_2.31"  # Ubuntu 20.04, Debian 11
             qt_version:
               - "5.15.2"
-              - "5.15.13"
+              - "5.15.14"
             exclude:
               - binary_compatibility: glibc_2.23
                 qt_version: "5.15.2"
               - binary_compatibility: glibc_2.27
-                qt_version: "5.15.13"
+                qt_version: "5.15.14"
             include:
               - binary_compatibility: glibc_2.23
                 container: ghcr.io/${{ github.repository }}/gha-build-runner-xenial
@@ -254,7 +254,9 @@ jobs:
               shell: docker-shell {0}
               working-directory: ${{ env.PORTABLE_DIR }}
               run: |
-                LIBCRYPTO=$(ldd plugins/libDbSqliteCipher.so | grep crypto | awk '{print $3}')
+                set -x
+                LDD_OUTPUT="$(ldd plugins/libDbSqliteCipher.so | grep crypto || true)"
+                LIBCRYPTO=$(echo "$LDD_OUTPUT" | awk '{print $3}')
                 REAL_LIBCRYPTO=$(readlink -e $LIBCRYPTO)
                 cp -P $REAL_LIBCRYPTO lib/$(basename -- $LIBCRYPTO)
 
@@ -263,7 +265,7 @@ jobs:
               shell: docker-shell {0}
               working-directory: /usr/local/lib
               run: |
-                cp libssl.so.1.1 libcrypto.so.1.1 $PORTABLE_DIR/lib/
+                cp libssl.so.3 libcrypto.so.3 $PORTABLE_DIR/lib/
 
             - name: Copy Qt's libcrypto and libssl to portable dir (#4577)
               if: env.USE_PREBUILT_QT == 0
@@ -406,13 +408,13 @@ jobs:
                     SQLiteStudio-$PACKAGE_VERSION-installer.run
 
             - name: Upload package artifact
-              uses: actions/upload-artifact@v1
+              uses: actions/upload-artifact@v4
               with:
                 name: sqlitestudio-${{ env.PACKAGE_VERSION }}.tar.xz
                 path: output/portable/sqlitestudio-${{ env.PACKAGE_VERSION }}.tar.xz
 
             - name: Upload installer artifact
-              uses: actions/upload-artifact@v1
+              uses: actions/upload-artifact@v4
               with:
                 name: SQLiteStudio-${{ env.PACKAGE_VERSION }}-installer.run
                 path: SQLiteStudio-${{ env.PACKAGE_VERSION }}-installer.run

--- a/.github/workflows/lin_runner.yml
+++ b/.github/workflows/lin_runner.yml
@@ -2,7 +2,7 @@ name: "Linux build runner image"
 
 env:
     icu_version: "74.2"
-    openssl_version: "1.1.1w"
+    openssl_version: "3.0.14"
     python_version: "3.9.19"
     tcl_version: "8.6.14"
 
@@ -36,7 +36,7 @@ jobs:
               run: |
                 v=${{ env.icu_version }}
                 icu_url="https://github.com/unicode-org/icu/releases/download/release-${v%.*}-${v#*.}/icu4c-${v%.*}_${v#*.}-src.tgz"
-                openssl_url="https://github.com/openssl/openssl/releases/download/OpenSSL_$(echo ${{ env.openssl_version }} | tr . _)/openssl-${{ env.openssl_version }}.tar.gz"
+                openssl_url="https://www.openssl.org/source/openssl-${{ env.openssl_version }}.tar.gz"
                 python_url="https://www.python.org/ftp/python/${{ env.python_version }}/Python-${{ env.python_version }}.tar.xz"
                 tcl_url="https://downloads.sourceforge.net/project/tcl/Tcl/${{ env.tcl_version }}/tcl${{ env.tcl_version }}-src.tar.gz"
 
@@ -57,7 +57,7 @@ jobs:
                     && make -j$(nproc) && make install \
                     && cd ../.. && rm -fr icu
                 RUN curl -L $openssl_url | tar -xz \
-                    && cd openssl-${{ env.openssl_version }} && ./config --prefix=/usr/local --openssldir=/usr/local/ssl \
+                    && cd openssl-${{ env.openssl_version }} && ./config --prefix=/usr/local --openssldir=/usr/local/ssl --libdir=lib \
                     && make -j$(nproc) && make install \
                     && cd ../.. && rm -fr openssl-${{ env.openssl_version }}
                 # Installing Python under /usr improves our chances to match user's installed Python


### PR DESCRIPTION
Qt 5 now supports OpenSSL 3, so use that. The lin_runner.yml workflow needs to be run once, as usual.