### PR TITLE
A possible fix for the file dialog issues

### DIFF
--- a/SQLiteStudio3/guiSQLiteStudio/dialogs/dbdialog.cpp
+++ b/SQLiteStudio3/guiSQLiteStudio/dialogs/dbdialog.cpp
@@ -145,6 +145,8 @@ void DbDialog::init()
 
     ui->testConnIcon->setVisible(false);
 
+    connect(ui->existingDatabaseRadio, SIGNAL(clicked()), this, SLOT(updateCreateMode()));
+    connect(ui->createDatabaseRadio, SIGNAL(clicked()), this, SLOT(updateCreateMode()));
     connect(ui->fileEdit, SIGNAL(textChanged(QString)), this, SLOT(fileChanged(QString)));
     connect(ui->nameEdit, SIGNAL(textEdited(QString)), this, SLOT(nameModified(QString)));
     connect(ui->browseOpenButton, SIGNAL(clicked()), this, SLOT(browseClicked()));
@@ -172,7 +174,9 @@ void DbDialog::updateOptions()
 
     customBrowseHandler = nullptr;
     ui->pathGroup->setTitle(tr("File"));
-    ui->browseOpenButton->setToolTip(tr("Select new or existing file on local computer"));
+    ui->existingDatabaseRadio->setChecked(true);
+    ui->createDatabaseRadio->setChecked(false);
+    updateCreateMode();
 
     optionWidgets.clear();
     optionKeyToWidget.clear();
@@ -209,6 +213,10 @@ void DbDialog::addOption(const DbPluginOption& option, int& row)
         // This option does not add any editor, but has it's own label for path edit.
         row--;
         ui->pathGroup->setTitle(option.label);
+        ui->existingDatabaseRadio->setChecked(true);
+        ui->createDatabaseRadio->setChecked(false);
+        ui->createDatabaseRadio->setVisible(false);
+        updateCreateMode();
         if (!option.toolTip.isEmpty())
             ui->browseOpenButton->setToolTip(option.toolTip);
 
@@ -689,7 +697,7 @@ void DbDialog::browseClicked()
     else
         dir = getFileDialogInitPath();
 
-    QString path = getDbPath(dir);
+    QString path = getDbPath(createMode, dir);
     if (path.isNull())
         return;
 
@@ -726,6 +734,15 @@ void DbDialog::nameModified(const QString &value)
 {
     nameManuallyEdited = !value.isEmpty();
     updateState();
+}
+
+void DbDialog::updateCreateMode()
+{
+    createMode = ui->createDatabaseRadio->isChecked();
+    ui->browseOpenButton->setToolTip(
+        createMode ? tr("Choose a location for the new database file")
+                   : tr("Browse for existing database file on local computer")
+    );
 }
 
 void DbDialog::accept()

--- a/SQLiteStudio3/guiSQLiteStudio/dialogs/dbdialog.h
+++ b/SQLiteStudio3/guiSQLiteStudio/dialogs/dbdialog.h
@@ -74,6 +74,7 @@ class GUI_API_EXPORT DbDialog : public QDialog
         bool disableTypeAutodetection = false;
         bool doAutoTest = false;
         bool nameManuallyEdited = false;
+        bool createMode = false;
         ImmediateTooltip* connIconTooltip = nullptr;
 
         static const constexpr int ADDITIONAL_ROWS_BEGIN_INDEX = 1;
@@ -88,6 +89,7 @@ class GUI_API_EXPORT DbDialog : public QDialog
         void propertyChanged();
         void dbTypeChanged(int index);
         void nameModified(const QString &value);
+        void updateCreateMode();
 
     public slots:
         void accept();

--- a/SQLiteStudio3/guiSQLiteStudio/dialogs/dbdialog.ui
+++ b/SQLiteStudio3/guiSQLiteStudio/dialogs/dbdialog.ui
@@ -44,20 +44,41 @@
      <property name="title">
       <string>File</string>
      </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_5">
+     <layout class="QVBoxLayout" name="verticalLayout_3">
       <item>
-       <widget class="QLineEdit" name="fileEdit"/>
-      </item>
-      <item>
-       <widget class="QToolButton" name="browseOpenButton">
+       <widget class="QRadioButton" name="existingDatabaseRadio">
         <property name="text">
-         <string/>
+         <string>Select an existing database file</string>
         </property>
-        <property name="icon">
-         <iconset resource="../icons.qrc">
-          <normaloff>:/icons/img/open_sql_file.png</normaloff>:/icons/img/open_sql_file.png</iconset>
+        <property name="checked">
+         <bool>true</bool>
         </property>
        </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="createDatabaseRadio">
+        <property name="text">
+         <string>Create a new database file</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_5">
+        <item>
+         <widget class="QLineEdit" name="fileEdit"/>
+        </item>
+        <item>
+         <widget class="QToolButton" name="browseOpenButton">
+          <property name="text">
+           <string/>
+          </property>
+          <property name="icon">
+           <iconset resource="../icons.qrc">
+            <normaloff>:/icons/img/open_sql_file.png</normaloff>:/icons/img/open_sql_file.png</iconset>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
      </layout>
     </widget>

--- a/SQLiteStudio3/guiSQLiteStudio/uiutils.cpp
+++ b/SQLiteStudio3/guiSQLiteStudio/uiutils.cpp
@@ -35,7 +35,7 @@ const QStringList pageSizes = map<QPageSize::PageSizeId, QString>(pageSizeIds, [
 
 const QStringList pageSizesWithDimensions;
 
-QString getDbPath(const QString &startWith)
+QString getDbPath(bool newFileMode, const QString &startWith)
 {
     QString dir = startWith;
     if (dir.isNull())
@@ -48,8 +48,15 @@ QString getDbPath(const QString &startWith)
     });
 
     QFileDialog dialog(nullptr, QObject::tr("Select database file"), dir, QString());
-    dialog.setAcceptMode(QFileDialog::AcceptOpen);
+    dialog.setAcceptMode(newFileMode ? QFileDialog::AcceptSave : QFileDialog::AcceptOpen);
+
+    /* As we don't actually overwrite a selected existing database file, switch off the
+     * overwrite warning.
+     * FIXME: QFileDialog::DontConfirmOverwrite does not work on MacOS native dialogs.
+     * Probably some better UX is needed.
+     */
     dialog.setOption(QFileDialog::DontConfirmOverwrite, true);
+
     dialog.setLabelText(QFileDialog::Accept, QObject::tr("Select"));
     dialog.setLabelText(QFileDialog::FileType, QObject::tr("File type"));
     dialog.setNameFilters(filters);

--- a/SQLiteStudio3/guiSQLiteStudio/uiutils.h
+++ b/SQLiteStudio3/guiSQLiteStudio/uiutils.h
@@ -8,7 +8,7 @@
 class QWidget;
 class QToolBar;
 
-GUI_API_EXPORT QString getDbPath(const QString& startWith = QString());
+GUI_API_EXPORT QString getDbPath(bool newFileMode, const QString& startWith = QString());
 GUI_API_EXPORT void setValidState(QWidget* widget, bool valid, const QString& message = QString());
 GUI_API_EXPORT void setValidStateWihtTooltip(QWidget* widget, const QString& tooltip, bool valid, const QString& message = QString());
 GUI_API_EXPORT void setValidStateWarning(QWidget* widget, const QString& warning);


### PR DESCRIPTION
This PR adds a runtime option to switch between native and Qt file dialog backends (set to native file dialogs by default). Then, for backends other than Windows and Qt/KDE, user interface before #4300 is restored (with a separate button to create a new database). It's a possible fix for #4796 and many user questions.

Fixes: #4796 