### PR TITLE
chillout: Remove unused #include (#4776)

### DIFF
--- a/SQLiteStudio3/coreSQLiteStudio/chillout/posix/posixcrashhandler.cpp
+++ b/SQLiteStudio3/coreSQLiteStudio/chillout/posix/posixcrashhandler.cpp
@@ -2,7 +2,6 @@
 
 #ifndef _WIN32
 
-#include <execinfo.h>
 #include <errno.h>
 #include <dlfcn.h>
 #include <cxxabi.h>


### PR DESCRIPTION
This header turned out to be unused.

Fixes: #4776.