### PR TITLE
Linux build: don't run InstallBuilder in container, Qt 5.15.2 OpenSSL update

### DIFF
--- a/.github/workflows/lin_release.yml
+++ b/.github/workflows/lin_release.yml
@@ -270,8 +270,8 @@ jobs:
             - name: Copy Qt's libcrypto and libssl to portable dir (#4577)
               if: env.USE_PREBUILT_QT == 0
               run: |
-                wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.22_amd64.deb
-                dpkg-deb -xv libssl1.1_1.1.1f-1ubuntu2.22_amd64.deb .
+                wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.23_amd64.deb
+                dpkg-deb -xv libssl1.1_1.1.1f-1ubuntu2.23_amd64.deb .
                 cp ./usr/lib/$TARGET_ARCH-linux-gnu/libssl.so.1.1 ${{ env.PORTABLE_DIR }}/lib/
                 cp ./usr/lib/$TARGET_ARCH-linux-gnu/libcrypto.so.1.1 ${{ env.PORTABLE_DIR }}/lib/
 
@@ -394,7 +394,7 @@ jobs:
                 ls -l
 
             - name: Create installer package
-              shell: docker-shell {0}
+              shell: bash
               env:
                 IB_LICENSE: ${{ secrets.INSTALLER_LICENSE }}
               run: |


### PR DESCRIPTION
This should fix the Linux Actions build once again.