### PR TITLE
Fix #4819 by resetting sort order that is no longer valid

### DIFF
--- a/SQLiteStudio3/coreSQLiteStudio/db/queryexecutorsteps/queryexecutororder.cpp
+++ b/SQLiteStudio3/coreSQLiteStudio/db/queryexecutorsteps/queryexecutororder.cpp
@@ -18,7 +18,11 @@ bool QueryExecutorOrder::exec()
 
     TokenList tokens = getOrderTokens(sortOrder);
     if (tokens.size() == 0)
-        return false;
+    {
+        // happens in cases like #4819
+        queryExecutor->setSortOrder(QueryExecutor::SortList());
+        return true;
+    }
 
     static_qstring(selectTpl, "SELECT * FROM (%1) ORDER BY %2");
     QString newSelect = selectTpl.arg(select->detokenize(), tokens.detokenize());

--- a/SQLiteStudio3/guiSQLiteStudio/datagrid/sqlquerymodel.cpp
+++ b/SQLiteStudio3/guiSQLiteStudio/datagrid/sqlquerymodel.cpp
@@ -1622,7 +1622,11 @@ void SqlQueryModel::storeStep1NumbersFromExecution()
 {
     lastExecutionTime = queryExecutor->getLastExecutionTime();
     page = queryExecutor->getPage();
-    sortOrder = queryExecutor->getSortOrder();
+
+    QueryExecutor::SortList newSortOrder = queryExecutor->getSortOrder();
+    if (!sortOrder.isEmpty() && newSortOrder.isEmpty())
+        notifyWarn(tr("There are less columns in the new query, sort order has been reset."));
+    sortOrder = newSortOrder;
     rowsAffected = queryExecutor->getRowsAffected();
 
     if (!queryExecutor->getSkipRowCounting())


### PR DESCRIPTION
This is an attempt at fixing #4819. I am not sure whether it's the right place to catch this condition, but seems to work well enough. Another option is to reset the model sort order on every new execution.