### PR TITLE
Warn user when registering a default collation

### DIFF
--- a/SQLiteStudio3/coreSQLiteStudio/db/abstractdb3.h
+++ b/SQLiteStudio3/coreSQLiteStudio/db/abstractdb3.h
@@ -6,6 +6,7 @@
 #include "common/utils_sql.h"
 #include "common/unused.h"
 #include "services/collationmanager.h"
+#include "services/notifymanager.h"
 #include "sqlitestudio.h"
 #include "db/sqlerrorcodes.h"
 #include "log.h"
@@ -849,7 +850,7 @@ void AbstractDb3<T>::registerDefaultCollation(void* fnUserData, typename T::hand
     if (res != T::OK)
         qWarning() << "Could not register default collation in AbstractDb3<T>::registerDefaultCollation().";
     else
-        qDebug() << "Registered default collation on demand, under name:" << collationName;
+        notifyWarn(tr("Registered default collation on demand, under name: %1").arg(collationName));
 }
 
 template <class T>


### PR DESCRIPTION
When an unknown collation is requested, e.g.:
```sql
WITH t (a) AS (VALUES ('a'), ('b'))
SELECT a FROM t
ORDER BY a COLLATE unicorn;
```
... SQLiteStudio silently registers a default collation under that name, so the query does not fail due to an unknown collation.

I cannot immediately imagine situations when this is wanted behaviour. At least, user deserves a visible warning when this happens. That's what this patch does.

See also: #4700.