### PR TITLE
Extension-based collations in the Collations editor

### DIFF
--- a/SQLiteStudio3/coreSQLiteStudio/db/abstractdb3.h
+++ b/SQLiteStudio3/coreSQLiteStudio/db/abstractdb3.h
@@ -556,6 +556,12 @@ bool AbstractDb3<T>::registerCollationInternal(const QString& name)
     if (!dbHandle)
         return false;
 
+    CollationManager::CollationPtr collation = COLLATIONS->getCollation(name);
+    if (collation == nullptr)
+        return false;
+    if (collation->type == CollationManager::CollationType::EXTENSION_BASED)
+        return !(exec(collation->code, Flag::NO_LOCK)->isError());
+
     CollationUserData* userData = new CollationUserData;
     userData->name = name;
 

--- a/SQLiteStudio3/coreSQLiteStudio/services/collationmanager.h
+++ b/SQLiteStudio3/coreSQLiteStudio/services/collationmanager.h
@@ -14,9 +14,15 @@ class API_EXPORT CollationManager : public QObject
     Q_OBJECT
 
     public:
+        enum CollationType
+        {
+            FUNCTION_BASED = 0,
+            EXTENSION_BASED = 1
+        };
         struct API_EXPORT Collation
         {
             QString name;
+            CollationType type;
             QString lang;
             QString code;
             QStringList databases;
@@ -30,6 +36,7 @@ class API_EXPORT CollationManager : public QObject
         virtual QList<CollationPtr> getCollationsForDatabase(const QString& dbName) const = 0;
         virtual int evaluate(const QString& name, const QString& value1, const QString& value2) = 0;
         virtual int evaluateDefault(const QString& value1, const QString& value2) = 0;
+        virtual CollationPtr getCollation(const QString &name) const = 0;
 
     signals:
         void collationListChanged();

--- a/SQLiteStudio3/coreSQLiteStudio/services/impl/collationmanagerimpl.cpp
+++ b/SQLiteStudio3/coreSQLiteStudio/services/impl/collationmanagerimpl.cpp
@@ -34,6 +34,16 @@ QList<CollationManager::CollationPtr> CollationManagerImpl::getAllCollations() c
     return collations;
 }
 
+CollationManager::CollationPtr CollationManagerImpl::getCollation(const QString &name) const
+{
+   if (!collationsByKey.contains(name))
+   {
+       qCritical() << "Could not find requested collation" << name << ".";
+       return nullptr;
+   }
+   return collationsByKey[name];
+}
+
 QList<CollationManager::CollationPtr> CollationManagerImpl::getCollationsForDatabase(const QString& dbName) const
 {
     QList<CollationPtr> results;
@@ -98,6 +108,7 @@ void CollationManagerImpl::storeInConfig()
     for (CollationPtr coll : collations)
     {
         collHash["name"] = coll->name;
+        collHash["type"] = coll->type;
         collHash["lang"] = coll->lang;
         collHash["code"] = coll->code;
         collHash["allDatabases"] = coll->allDatabases;
@@ -119,6 +130,10 @@ void CollationManagerImpl::loadFromConfig()
         collHash = var.toHash();
         coll = CollationPtr::create();
         coll->name = collHash["name"].toString();
+        if (collHash.contains("type") && collHash["type"].toInt() == CollationType::EXTENSION_BASED)
+            coll->type = CollationType::EXTENSION_BASED;
+        else
+            coll->type = CollationType::FUNCTION_BASED;
         coll->lang = updateScriptingQtLang(collHash["lang"].toString());
         coll->code = collHash["code"].toString();
         coll->databases = collHash["databases"].toStringList();

--- a/SQLiteStudio3/coreSQLiteStudio/services/impl/collationmanagerimpl.h
+++ b/SQLiteStudio3/coreSQLiteStudio/services/impl/collationmanagerimpl.h
@@ -19,6 +19,7 @@ class API_EXPORT CollationManagerImpl : public CollationManager
         QList<CollationPtr> getCollationsForDatabase(const QString& dbName) const;
         int evaluate(const QString& name, const QString& value1, const QString& value2);
         int evaluateDefault(const QString& value1, const QString& value2);
+        CollationPtr getCollation(const QString &name) const;
 
     private:
         void init();

--- a/SQLiteStudio3/guiSQLiteStudio/windows/collationseditor.h
+++ b/SQLiteStudio3/guiSQLiteStudio/windows/collationseditor.h
@@ -3,6 +3,7 @@
 
 #include "mdichild.h"
 #include "common/extactioncontainer.h"
+#include "services/collationmanager.h"
 #include <QItemSelection>
 #include <QModelIndex>
 #include <QWidget>
@@ -61,12 +62,14 @@ class GUI_API_EXPORT CollationsEditor : public MdiChild
     private:
         void init();
         int getCurrentCollationRow() const;
+        CollationManager::CollationType getCurrentType() const;
         void collationDeselected(int row);
         void collationSelected(int row);
         void clearEdits();
         void selectCollation(int row);
         QStringList getCurrentDatabases() const;
         void setFont(const QFont& font);
+        void updateLangCombo();
 
         Ui::CollationsEditor *ui = nullptr;
         CollationsEditorModel* model = nullptr;

--- a/SQLiteStudio3/guiSQLiteStudio/windows/collationseditor.ui
+++ b/SQLiteStudio3/guiSQLiteStudio/windows/collationseditor.ui
@@ -203,13 +203,38 @@
               <widget class="QLineEdit" name="nameEdit"/>
              </item>
              <item row="0" column="1">
+              <widget class="QLabel" name="typeLabel">
+               <property name="text">
+                <string>Collation type:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1">
+              <layout class="QVBoxLayout" name="verticalLayout_6">
+               <item>
+                <widget class="QRadioButton" name="functionBasedRadio">
+                 <property name="text">
+                  <string>Function-based</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QRadioButton" name="extensionBasedRadio">
+                 <property name="text">
+                  <string>Extension-based</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item row="0" column="2">
               <widget class="QLabel" name="langLabel">
                <property name="text">
                 <string>Implementation language:</string>
                </property>
               </widget>
              </item>
-             <item row="1" column="1">
+             <item row="1" column="2">
               <widget class="QComboBox" name="langCombo"/>
              </item>
             </layout>

--- a/SQLiteStudio3/guiSQLiteStudio/windows/collationseditormodel.cpp
+++ b/SQLiteStudio3/guiSQLiteStudio/windows/collationseditormodel.cpp
@@ -1,6 +1,7 @@
 #include "collationseditormodel.h"
 #include "common/unused.h"
 #include "common/strhash.h"
+#include "iconmanager.h"
 #include "services/pluginmanager.h"
 #include "plugins/scriptingplugin.h"
 #include "icon.h"
@@ -67,6 +68,16 @@ void CollationsEditorModel::setName(int row, const QString& name)
 QString CollationsEditorModel::getName(int row) const
 {
     GETTER(collationList[row]->data->name, QString());
+}
+
+void CollationsEditorModel::setType(int row, CollationManager::CollationType type)
+{
+    SETTER(collationList[row]->data->type, type);
+}
+
+CollationManager::CollationType CollationsEditorModel::getType(int row) const
+{
+    GETTER(collationList[row]->data->type, CollationManager::CollationType::FUNCTION_BASED);
 }
 
 void CollationsEditorModel::setLang(int row, const QString& lang)
@@ -248,13 +259,17 @@ QVariant CollationsEditorModel::data(const QModelIndex& index, int role) const
     if (role == Qt::DisplayRole)
         return collationList[index.row()]->data->name;
 
-    if (role == Qt::DecorationRole && langToIcon.contains(collationList[index.row()]->data->lang))
+    if (role == Qt::DecorationRole)
     {
-        QIcon icon = langToIcon[collationList[index.row()]->data->lang];
-        if (!collationList[index.row()]->valid)
-            icon = Icon::merge(icon, Icon::ERROR);
-
-        return icon;
+        auto coll = collationList[index.row()]->data;
+        bool isExtension = coll->type == CollationManager::CollationType::EXTENSION_BASED;
+        if (isExtension || langToIcon.contains(coll->lang))
+        {
+            QIcon icon = isExtension ? ICONS.EXTENSION : langToIcon[coll->lang];
+            if (!collationList[index.row()]->valid)
+                icon = Icon::merge(icon, Icon::ERROR);
+            return icon;
+        }
     }
 
     return QVariant();

--- a/SQLiteStudio3/guiSQLiteStudio/windows/collationseditormodel.h
+++ b/SQLiteStudio3/guiSQLiteStudio/windows/collationseditormodel.h
@@ -21,6 +21,8 @@ class GUI_API_EXPORT CollationsEditorModel : public QAbstractListModel
         void setModified(int row, bool modified);
         void setName(int row, const QString& name);
         QString getName(int row) const;
+        void setType(int row, CollationManager::CollationType type);
+        CollationManager::CollationType getType(int row) const;
         void setLang(int row, const QString& lang);
         QString getLang(int row) const;
         void setAllDatabases(int row, bool allDatabases);


### PR DESCRIPTION
This adds support for extension-based collations to the Collations Editor. It allows for persistent ICU collations, a feature requested in #4974.