### PR TITLE
UX: Radio button in Database dialog follows file existence

### DIFF
--- a/SQLiteStudio3/guiSQLiteStudio/dialogs/dbdialog.cpp
+++ b/SQLiteStudio3/guiSQLiteStudio/dialogs/dbdialog.cpp
@@ -671,6 +671,19 @@ void DbDialog::fileChanged(const QString &arg1)
     valueForNameGenerationChanged();
     updateType();
     propertyChanged();
+
+    if (!customBrowseHandler)
+    {
+        QString path = getPath();
+        if (!path.isEmpty())
+        {
+            QFileInfo fileInfo(path);
+            bool isFile = fileInfo.exists() && fileInfo.isFile();
+            ui->existingDatabaseRadio->setChecked(isFile);
+            ui->createDatabaseRadio->setChecked(!isFile);
+            updateCreateMode();
+        }
+    }
 }
 
 void DbDialog::browseClicked()


### PR DESCRIPTION
This is a followup to #5025. Let the Existing/New radio button state follow the changes in the text entry.