### PR TITLE
Fix CREATE VIEW column list syntax support in the View window and in the smart query executor

### DIFF
--- a/SQLiteStudio3/coreSQLiteStudio/parser/ast/sqlitecreateview.h
+++ b/SQLiteStudio3/coreSQLiteStudio/parser/ast/sqlitecreateview.h
@@ -23,6 +23,7 @@ class API_EXPORT SqliteCreateView : public SqliteQuery, public SqliteDdlWithDbCo
         void setTargetDatabase(const QString& database);
         QString getObjectName() const;
         void setObjectName(const QString& name);
+        TokenList equivalentSelectTokens() const;
 
         bool tempKw = false;
         bool temporaryKw = false;

--- a/SQLiteStudio3/guiSQLiteStudio/windows/viewwindow.cpp
+++ b/SQLiteStudio3/guiSQLiteStudio/windows/viewwindow.cpp
@@ -299,7 +299,7 @@ void ViewWindow::initView()
     if (existingView)
     {
         dataModel->setDb(db);
-        dataModel->setQuery(originalCreateView->select->detokenize());
+        dataModel->setQuery(originalCreateView->equivalentSelectTokens().detokenize());
         dataModel->setDatabaseAndView(database, view);
         ui->dbCombo->setDisabled(true);
     }


### PR DESCRIPTION
The issue with the View window is reported in #4853. There was also an issue with the smart query executor which failed to properly inline such views.