### PR TITLE
ScriptingPython: portable version binds to Python library 2.7-3.13 at runtime

### DIFF
--- a/.github/workflows/lin_release.yml
+++ b/.github/workflows/lin_release.yml
@@ -4,7 +4,6 @@ env:
     TCL_VERSION: '8.6.14'
     SQLITE_VERSION: '3410200'
     SQLITE_RELEASE_YEAR: '2023'
-    PYTHON_VERSION: '3.9'
     ICU_VERSION: '74.2'
     PORTABLE_DIR: ${{ github.workspace }}/output/portable/SQLiteStudio
     INSTALLBUILDER_DIR: ../ib
@@ -50,9 +49,11 @@ jobs:
               - binary_compatibility: glibc_2.23
                 container: ghcr.io/${{ github.repository }}/gha-build-runner-xenial
                 icu_version_short: 66
+                python_version: 3.5
               - binary_compatibility: glibc_2.27
                 container: ghcr.io/${{ github.repository }}/gha-build-runner-bionic
                 icu_version_short: 60
+                python_version: 3.6
               #- binary_compatibility: glibc_2.31
               #  container: ghcr.io/${{ github.repository }}/gha-build-runner-focal
               #  icu_version_short: 66
@@ -73,7 +74,7 @@ jobs:
                     echo TARGET_ARCH=x86_64
                 } >> $GITHUB_ENV
 
-            - name: Configure prebuilt python${{ env.PYTHON_VERSION }}
+            - name: Configure python${{ matrix.python_version }} from distribution
               run: |
                 echo "pythonLocation=/usr/" >> $GITHUB_ENV
 
@@ -231,7 +232,7 @@ jobs:
                 qmake \
                     $([ ${{ inputs.use_ccache || false }} = false ] || echo "CONFIG+=ccache") \
                     CONFIG+=portable \
-                    PYTHON_VERSION=$PYTHON_VERSION "INCLUDEPATH+=$pythonLocation/include/python$PYTHON_VERSION" "LIBS += -L$pythonLocation/lib" \
+                    "INCLUDEPATH+=$pythonLocation/include/python${{ matrix.python_version}}" \
                     ../../../Plugins
                 make -j 1  # Parallel plugin build crashes randomly
 

--- a/.github/workflows/lin_runner.yml
+++ b/.github/workflows/lin_runner.yml
@@ -4,7 +4,6 @@ env:
     freetype_version: "2.13.2"
     icu_version: "74.2"
     openssl_version: "3.0.14"
-    python_version: "3.9.19"
     tcl_version: "8.6.14"
 
 on:
@@ -39,7 +38,6 @@ jobs:
                 freetype_url="https://download.savannah.gnu.org/releases/freetype/freetype-${{ env.freetype_version }}.tar.xz"
                 icu_url="https://github.com/unicode-org/icu/releases/download/release-${v%.*}-${v#*.}/icu4c-${v%.*}_${v#*.}-src.tgz"
                 openssl_url="https://www.openssl.org/source/openssl-${{ env.openssl_version }}.tar.gz"
-                python_url="https://www.python.org/ftp/python/${{ env.python_version }}/Python-${{ env.python_version }}.tar.xz"
                 tcl_url="https://downloads.sourceforge.net/project/tcl/Tcl/${{ env.tcl_version }}/tcl${{ env.tcl_version }}-src.tar.gz"
 
                 tee Dockerfile <<EOF_Dockerfile
@@ -63,18 +61,7 @@ jobs:
                     && cd openssl-${{ env.openssl_version }} && ./config --prefix=/usr/local --openssldir=/usr/local/ssl --libdir=lib \
                     && make -j$(nproc) && make install \
                     && cd ../.. && rm -fr openssl-${{ env.openssl_version }}
-                # Installing Python under /usr improves our chances to match user's installed Python
-                # On Bionic, install system python3 first so it is not reinstalled by aqtinstall later
-                RUN curl -L $python_url | xz -dc | tar -x \
-                    && apt-get -y install libbz2-dev libffi-dev libgdbm-dev liblzma-dev libsqlite3-dev uuid-dev zlib1g-dev \
-                    && case ${{ matrix.release }} in xenial*) ;; *) apt-get -y install libgdbm-compat-dev ;; esac \
-                    && case ${{ matrix.release }} in bionic*) apt-get -y install python3 python3-distutils python3-lib2to3 python3-minimal ;; esac \
-                    && cd Python-${{ env.python_version }} && ./configure --prefix=/usr --with-openssl=/usr/local --enable-optimizations --enable-shared --without-static-libpython \
-                    && make -j$(nproc) && make install \
-                    && ln -fns python${python_version%.*} /usr/bin/python3 \
-                    && cd ../../ && rm -fr Python-${{ env.python_version }} \
-                    && if [ ${{ matrix.release }} != xenial ]; then apt-get -y remove libgdbm-compat-dev; fi \
-                    && apt-get -y remove libbz2-dev libffi-dev libgdbm-dev liblzma-dev libsqlite3-dev uuid-dev zlib1g-dev
+                RUN apt-get -y install python3-dev
                 RUN curl -L $tcl_url | tar -xz \
                     && cd tcl${{ env.tcl_version }}/unix && ./configure --prefix=/usr/local \
                     && make -j$(nproc) && make install \

--- a/.github/workflows/mac_release.yml
+++ b/.github/workflows/mac_release.yml
@@ -316,7 +316,7 @@ jobs:
                     $([ ${{ inputs.use_ccache || false }} = false ] || echo "CONFIG+=ccache") \
                     QMAKE_CXXFLAGS+="${{ matrix.cflags }}" \
                     CONFIG+=portable \
-                    PYTHON_VERSION=$PYTHON_VERSION "INCLUDEPATH+=$pythonLocation/include/python$PYTHON_VERSION" "LIBS += -L$pythonLocation/lib" \
+                    "INCLUDEPATH+=$pythonLocation/include/python$PYTHON_VERSION" \
                     ../../../Plugins
                 make -j 1
 
@@ -349,24 +349,16 @@ jobs:
                     --setvars project.version=${{ env.SQLITESTUDIO_VERSION }}
                 ls -l
 
-            - name: Rename packages
+            - name: Rename package
               run: |
                 mv output/SQLiteStudio/sqlitestudio-${{ env.SQLITESTUDIO_VERSION }}.dmg \
                   sqlitestudio-${{ env.SQLITESTUDIO_VERSION }}${{ matrix.dmg_postfix }}.dmg
-                mv output/SQLiteStudio/sqlitestudio-${{ env.SQLITESTUDIO_VERSION }}-py${{ env.PYTHON_VERSION }}.dmg \
-                  sqlitestudio-${{ env.SQLITESTUDIO_VERSION }}-py${{ env.PYTHON_VERSION }}${{ matrix.dmg_postfix }}.dmg
 
             - name: Upload package artifact
               uses: actions/upload-artifact@v4
               with:
                 name: sqlitestudio-${{ env.SQLITESTUDIO_VERSION }}${{ matrix.dmg_postfix }}.dmg
                 path: sqlitestudio-${{ env.SQLITESTUDIO_VERSION }}${{ matrix.dmg_postfix }}.dmg
-
-            - name: Upload package artifact with Python
-              uses: actions/upload-artifact@v4
-              with:
-                name: sqlitestudio-${{ env.SQLITESTUDIO_VERSION }}-py${{ env.PYTHON_VERSION }}${{ matrix.dmg_postfix }}.dmg
-                path: sqlitestudio-${{ env.SQLITESTUDIO_VERSION }}-py${{ env.PYTHON_VERSION }}${{ matrix.dmg_postfix }}.dmg
 
             - name: Upload installer artifact
               uses: actions/upload-artifact@v4
@@ -377,12 +369,6 @@ jobs:
     build-universal:
         runs-on: macos-12  # Don't use newer versions yet, https://github.com/actions/runner-images/issues/7522
         needs: build
-        strategy:
-          fail-fast: false
-          matrix:
-            variant:
-              - '-py*'
-              - ''
         steps:
             - uses: actions/checkout@v4
               with:
@@ -390,17 +376,17 @@ jobs:
 
             - uses: actions/download-artifact@v4
               with:
-                pattern: sqlitestudio-[0-9].[0-9].[0-9]${{ matrix.variant }}-macos10.13.dmg
+                pattern: sqlitestudio-[0-9].[0-9].[0-9]-macos10.13.dmg
                 merge-multiple: true
 
             - uses: actions/download-artifact@v4
               with:
-                pattern: sqlitestudio-[0-9].[0-9].[0-9]${{ matrix.variant }}-macos11.arm64.dmg
+                pattern: sqlitestudio-[0-9].[0-9].[0-9]-macos11.arm64.dmg
                 merge-multiple: true
 
             - run: |
                 set -x
-                _prefix="$(echo sqlitestudio-[0-9].[0-9].[0-9]${{ matrix.variant }}-macos11.arm64.dmg | sed 's/11.arm64.dmg$//')"
+                _prefix="$(echo sqlitestudio-[0-9].[0-9].[0-9]-macos11.arm64.dmg | sed 's/11.arm64.dmg$//')"
                 SQLiteStudio3/create_macosx_bundle.sh -u "${_prefix}10.13.dmg" "${_prefix}11.arm64.dmg" "${_prefix}-universal.dmg"
                 echo "PACKAGE_NAME=${_prefix}-universal.dmg" >> $GITHUB_ENV
 

--- a/.github/workflows/win32_release.yml
+++ b/.github/workflows/win32_release.yml
@@ -262,7 +262,7 @@ jobs:
                 ${{ env.QMAKE_COMMAND }} \
                     "QMAKE_CXX=${{ env.GXX_COMMAND }}" \
                     CONFIG+=portable \
-                    PYTHON_VERSION=${{ env.PYTHON_VERSION }} "INCLUDEPATH+=${{ env.pythonLocation }}/include" "LIBS += -L${{ env.pythonLocation }}" \
+                    "INCLUDEPATH+=${{ env.pythonLocation }}/include" \
                     ../../../Plugins
                 mingw32-make.exe -j 1
 

--- a/.github/workflows/win64_release.yml
+++ b/.github/workflows/win64_release.yml
@@ -265,7 +265,7 @@ jobs:
                 ${{ env.QMAKE_COMMAND }} \
                     "QMAKE_CXX=${{ env.GXX_COMMAND }}" \
                     CONFIG+=portable \
-                    PYTHON_VERSION=${{ env.PYTHON_VERSION }} "INCLUDEPATH+=${{ env.pythonLocation }}/include" "LIBS += -L${{ env.pythonLocation }}" \
+                    "INCLUDEPATH+=${{ env.pythonLocation }}/include" \
                     ../../../Plugins
                 mingw32-make.exe -j 1
 

--- a/Plugins/ScriptingPython/ScriptingPython.pro
+++ b/Plugins/ScriptingPython/ScriptingPython.pro
@@ -7,8 +7,6 @@ TEMPLATE = lib
 
 DEFINES += SCRIPTINGPYTHON_LIBRARY
 
-QMAKE_CXXFLAGS += -Wno-cast-function-type
-
 SOURCES += scriptingpython.cpp
 
 HEADERS += scriptingpython.h\
@@ -17,22 +15,40 @@ HEADERS += scriptingpython.h\
 OTHER_FILES += \
     scriptingpython.json
 
-isEmpty(PYTHON_VERSION) {
-    PYTHON_VERSION = 3.9
+portable {
+    CONFIG += dynamic_python
 }
 
-linux: {
-    LIBS += -lpython$$PYTHON_VERSION
+dynamic_python {
+    DEFINES += PYTHON_DYNAMIC_BINDING
+    SOURCES += dynamicpythonapi.cpp
+    HEADERS += dynamicpythonapi.h
 }
 
-macx: {
-    LIBS += -lpython$$PYTHON_VERSION
+!dynamic_python {
+    HEADERS += staticpythonapi.h
+
+    isEmpty(PYTHON_VERSION) {
+        PYTHON_VERSION = 3.9
+    }
+    linux: {
+        LIBS += -lpython$$PYTHON_VERSION
+    }
+
+    macx: {
+        LIBS += -lpython$$PYTHON_VERSION
+    }
+    win32: {
+        LIBS += -lpython$$replace(PYTHON_VERSION, \., ) -L$$PWD/../../../lib/python
+    }
 }
 
 win32: {
     INCLUDEPATH += $$PWD/../../../include/python
-    LIBS += -lpython$$replace(PYTHON_VERSION, \., ) -L$$PWD/../../../lib/python
 }
+
+FORMS += \
+    scriptingpython.ui
 
 RESOURCES += \
     scriptingpython.qrc

--- a/Plugins/ScriptingPython/dynamicpythonapi.cpp
+++ b/Plugins/ScriptingPython/dynamicpythonapi.cpp
@@ -1,0 +1,99 @@
+#define DYNAMICPYTHONAPI_INTERNAL
+#include "dynamicpythonapi.h"
+#include <QDebug>
+
+// Needed to build a Python 2.7..3.10 ABI compatible plugin with Python 3.11+ SDK
+struct py_compat_frame_head {
+    PyObject_VAR_HEAD
+    struct _frame *f_back;
+    PyCodeObject *f_code;
+    PyObject *f_builtins;
+    PyObject *f_globals;
+    PyObject *f_locals;
+};
+
+// Define all variables
+#define PYAPI_DATA(x)   typeof(DynamicPythonApi::p##x) DynamicPythonApi::p##x = nullptr;
+#define PYAPI_METHOD(x) typeof(DynamicPythonApi::x) DynamicPythonApi::x = nullptr;
+DYNAMICPYTHONAPI_MEMBERS
+PYAPI_METHOD(_PyUnicode_AsDefaultEncodedString)
+PYAPI_METHOD(Py_InitModule4)
+PYAPI_METHOD(PyUnicode_SetDefaultEncoding)
+#undef PYAPI_DATA
+#undef PYAPI_METHOD
+
+PyObject* DynamicPythonApi::py27compat_PyModule_Create2(PyModuleDef* module, int apiver)
+{
+    return Py_InitModule4(module->m_name, module->m_methods, module->m_doc, NULL, apiver);
+}
+
+const char* DynamicPythonApi::py27compat_PyUnicode_AsUTF8AndSize(PyObject *unicode, Py_ssize_t *size)
+{
+    char *buf;
+    PyObject *bytes = _PyUnicode_AsDefaultEncodedString(unicode, "strict");
+    if (PyBytes_AsStringAndSize(bytes, &buf, size))
+        return NULL;
+    return const_cast<const char *>(buf);
+}
+
+
+bool DynamicPythonApi::bindSymbols(QLibrary &library)
+{
+    // First, try to bind all DYNAMICPYTHONAPI_MEMBERS
+#define PYAPI_DATA(x)   p##x = (typeof(p##x))library.resolve(#x);
+#define PYAPI_METHOD(x) x = (typeof(x))library.resolve(#x);
+    DYNAMICPYTHONAPI_MEMBERS
+
+    // Next, try resolve replacements for missing symbols
+#define PYAPI_METHOD_DEFAULT(x, y) \
+    if (x == nullptr) \
+        x = (typeof(::x)*)y
+
+    // Python 2.7
+    PYAPI_METHOD_DEFAULT(PyBytes_AsStringAndSize, library.resolve("PyString_AsStringAndSize"));
+    PYAPI_METHOD_DEFAULT(PyBytes_FromStringAndSize, library.resolve("PyString_FromStringAndSize"));
+    if (PyModule_Create2 == nullptr)
+    {
+        PYAPI_METHOD(Py_InitModule4)
+        PYAPI_METHOD_DEFAULT(Py_InitModule4, library.resolve("Py_InitModule4_64"));
+        if (Py_InitModule4 != nullptr)
+            PYAPI_METHOD_DEFAULT(PyModule_Create2, py27compat_PyModule_Create2);
+    }
+    PYAPI_METHOD_DEFAULT(PyUnicode_AsUTF8String, library.resolve("PyUnicodeUCS4_AsUTF8String"));
+    PYAPI_METHOD_DEFAULT(PyUnicode_AsUTF8String, library.resolve("PyUnicodeUCS2_AsUTF8String"));
+    if (PyUnicode_AsUTF8AndSize == nullptr)
+    {
+        _PyUnicode_AsDefaultEncodedString = nullptr;
+        PYAPI_METHOD_DEFAULT(_PyUnicode_AsDefaultEncodedString, library.resolve("_PyUnicodeUCS4_AsDefaultEncodedString"));
+        PYAPI_METHOD_DEFAULT(_PyUnicode_AsDefaultEncodedString, library.resolve("_PyUnicodeUCS2_AsDefaultEncodedString"));
+        PyUnicode_SetDefaultEncoding = nullptr;
+        PYAPI_METHOD_DEFAULT(PyUnicode_SetDefaultEncoding, library.resolve("PyUnicodeUCS4_SetDefaultEncoding"));
+        PYAPI_METHOD_DEFAULT(PyUnicode_SetDefaultEncoding, library.resolve("PyUnicodeUCS2_SetDefaultEncoding"));
+        if (PyUnicode_SetDefaultEncoding != nullptr &&
+            _PyUnicode_AsDefaultEncodedString != nullptr)
+            PYAPI_METHOD_DEFAULT(PyUnicode_AsUTF8AndSize, py27compat_PyUnicode_AsUTF8AndSize);
+    }
+    PYAPI_METHOD_DEFAULT(PyUnicode_FromStringAndSize, library.resolve("PyUnicodeUCS4_FromStringAndSize"));
+    PYAPI_METHOD_DEFAULT(PyUnicode_FromStringAndSize, library.resolve("PyUnicodeUCS2_FromStringAndSize"));
+
+    // Python 2.7..3.10
+    PYAPI_METHOD_DEFAULT(PyFrame_GetGlobals, [](PyFrameObject *frame) {
+        return reinterpret_cast<struct py_compat_frame_head*>(frame)->f_globals;
+    });
+    PYAPI_METHOD_DEFAULT(PyFrame_GetLocals, [](PyFrameObject *frame) {
+        return reinterpret_cast<struct py_compat_frame_head*>(frame)->f_locals;
+    });
+
+#undef PYAPI_DATA
+#undef PYAPI_METHOD
+#undef PYAPI_METHOD_DEFAULT
+
+    // Now, report any required DYNAMICPYTHONAPI_MEMBERS that could not be bound.
+    bool result = true;
+#define PYAPI_DATA(x)   if (p##x == nullptr) { qWarning() << "Could not bind symbol: "#x; result = false; }
+#define PYAPI_METHOD(x) if (x == nullptr) { qWarning() << "Could not bind symbol: "#x; result = false; }
+    DYNAMICPYTHONAPI_MEMBERS
+#undef PYAPI_DATA
+#undef PYAPI_METHOD
+    return result;
+}

--- a/Plugins/ScriptingPython/dynamicpythonapi.h
+++ b/Plugins/ScriptingPython/dynamicpythonapi.h
@@ -1,0 +1,156 @@
+#ifndef DYNAMICPYTHONAPI_H
+#define DYNAMICPYTHONAPI_H
+
+// We require Python 3.x headers
+#include <Python.h>
+#include <frameobject.h>
+
+#include <QLibrary>
+
+#ifndef METH_FASTCALL
+// In Python pre-3.6 SDK, this is undefined
+#define METH_FASTCALL 0x0080
+#endif
+
+// In Python 3.x SDK, we need these prototypes for binding to 2.7 library
+extern PyObject *Py_InitModule4(const char*, PyMethodDef*, const char*, PyObject*, int);
+extern PyObject *_PyUnicode_AsDefaultEncodedString(PyObject*, const char*);
+extern int PyUnicode_SetDefaultEncoding(const char*);
+
+#if PY_VERSION_HEX < 0x030b0000
+// In Python pre-3.11 SDK, we need these prototypes from future
+extern PyObject* PyFrame_GetGlobals(PyFrameObject*);
+extern PyObject* PyFrame_GetLocals(PyFrameObject*);
+#endif
+
+// Define a list of symbols, which is then used once in class declaration and
+// three times in the implementation
+#define DYNAMICPYTHONAPI_MEMBERS \
+    PYAPI_DATA(PyBool_Type) \
+    PYAPI_DATA(PyByteArray_Type) \
+    PYAPI_DATA(PyFloat_Type) \
+    PYAPI_DATA(PySet_Type) \
+    PYAPI_DATA(PyExc_RuntimeError) \
+    PYAPI_METHOD(Py_DecRef) \
+    PYAPI_METHOD(Py_EndInterpreter) \
+    PYAPI_METHOD(Py_Finalize) \
+    PYAPI_METHOD(Py_GetVersion) \
+    PYAPI_METHOD(Py_IncRef) \
+    PYAPI_METHOD(Py_Initialize) \
+    PYAPI_METHOD(Py_NewInterpreter) \
+    PYAPI_METHOD(PyBool_FromLong) \
+    PYAPI_METHOD(PyByteArray_AsString) \
+    PYAPI_METHOD(PyByteArray_Size) \
+    PYAPI_METHOD(PyBytes_AsStringAndSize) \
+    PYAPI_METHOD(PyBytes_FromStringAndSize) \
+    PYAPI_METHOD(PyDict_Clear) \
+    PYAPI_METHOD(PyDict_GetItemString) \
+    PYAPI_METHOD(PyDict_New) \
+    PYAPI_METHOD(PyDict_Next) \
+    PYAPI_METHOD(PyDict_SetItemString) \
+    PYAPI_METHOD(PyErr_Clear) \
+    PYAPI_METHOD(PyErr_Fetch) \
+    PYAPI_METHOD(PyErr_Occurred) \
+    PYAPI_METHOD(PyErr_SetString) \
+    PYAPI_METHOD(PyEval_GetFrame) \
+    PYAPI_METHOD(PyEval_InitThreads) \
+    PYAPI_METHOD(PyEval_ReleaseThread) \
+    PYAPI_METHOD(PyEval_RestoreThread) \
+    PYAPI_METHOD(PyFloat_AsDouble) \
+    PYAPI_METHOD(PyFloat_FromDouble) \
+    PYAPI_METHOD(PyFrame_GetGlobals) \
+    PYAPI_METHOD(PyFrame_GetLocals) \
+    PYAPI_METHOD(PyFrame_FastToLocals) \
+    PYAPI_METHOD(PyImport_AddModule) \
+    PYAPI_METHOD(PyImport_AppendInittab) \
+    PYAPI_METHOD(PyIter_Next) \
+    PYAPI_METHOD(PyList_Append) \
+    PYAPI_METHOD(PyList_GetItem) \
+    PYAPI_METHOD(PyList_New) \
+    PYAPI_METHOD(PyList_SetItem) \
+    PYAPI_METHOD(PyList_Size) \
+    PYAPI_METHOD(PyLong_AsLongLong) \
+    PYAPI_METHOD(PyLong_FromLongLong) \
+    PYAPI_METHOD(PyLong_FromUnsignedLongLong) \
+    PYAPI_METHOD(PyMapping_Check) \
+    PYAPI_METHOD(PyMapping_GetItemString) \
+    PYAPI_METHOD(PyModule_Create2) \
+    PYAPI_METHOD(PyModule_GetDict) \
+    PYAPI_METHOD(PyObject_CallObject) \
+    PYAPI_METHOD(PyObject_GetAttrString) \
+    PYAPI_METHOD(PyObject_GetIter) \
+    PYAPI_METHOD(PyObject_IsTrue) \
+    PYAPI_METHOD(PyObject_Repr) \
+    PYAPI_METHOD(PyRun_SimpleStringFlags) \
+    PYAPI_METHOD(PyRun_StringFlags) \
+    PYAPI_METHOD(PyThreadState_Get) \
+    PYAPI_METHOD(PyTuple_GetItem) \
+    PYAPI_METHOD(PyTuple_New) \
+    PYAPI_METHOD(PyTuple_SetItem) \
+    PYAPI_METHOD(PyTuple_Size) \
+    PYAPI_METHOD(PyType_IsSubtype) \
+    PYAPI_METHOD(PyUnicode_AsUTF8AndSize) \
+    PYAPI_METHOD(PyUnicode_AsUTF8String) \
+    PYAPI_METHOD(PyUnicode_FromStringAndSize)
+
+class DynamicPythonApi
+{
+    public:
+        static bool bindSymbols(QLibrary &library);
+        static PyObject* py27compat_PyModule_Create2(PyModuleDef* module, int apiver);
+        static const char* py27compat_PyUnicode_AsUTF8AndSize(PyObject *unicode, Py_ssize_t *size);
+
+#define PYAPI_DATA(name) static typeof(::name)* p##name;
+#define PYAPI_METHOD(name) static typeof(::name)* name;
+// We need PyEval_InitThreads deprecated since Python 3.7 SDK
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+        DYNAMICPYTHONAPI_MEMBERS
+#pragma GCC diagnostic pop
+        // These are all Python 2.7-only symbols we need:
+        PYAPI_METHOD(_PyUnicode_AsDefaultEncodedString)
+        PYAPI_METHOD(Py_InitModule4)
+        PYAPI_METHOD(PyUnicode_SetDefaultEncoding)
+#undef PYAPI_DATA
+#undef PYAPI_METHOD
+};
+
+// Redefine Python macros
+
+#undef Py_DECREF
+#undef Py_INCREF
+#undef Py_XDECREF
+#undef PyBool_Check
+#undef PyByteArray_Check
+#undef PyBytes_Check
+#undef PyDict_Check
+#undef PyFloat_Check
+#undef PyList_Check
+#undef PyLong_Check
+#undef PySet_Check
+#undef PyTuple_Check
+#undef PyUnicode_Check
+
+#define Py_DECREF Py_DecRef
+#define Py_INCREF Py_IncRef
+#define Py_XDECREF Py_DecRef
+
+#define PyBool_Check(x)      (Py_TYPE((x)) == pPyBool_Type)
+#define PyByteArray_Check(x) PyObject_TypeCheck((x), pPyByteArray_Type)
+#define PyBytes_Check(x)     PyType_HasFeature(Py_TYPE((x)), Py_TPFLAGS_BYTES_SUBCLASS)
+#define PyDict_Check(x)	     PyType_HasFeature(Py_TYPE((x)), Py_TPFLAGS_DICT_SUBCLASS)
+#define PyFloat_Check(x)     PyObject_TypeCheck((x), pPyFloat_Type)
+#define PyList_Check(x)      PyType_HasFeature(Py_TYPE((x)), Py_TPFLAGS_LIST_SUBCLASS)
+#define PyLong_Check(x)      PyType_HasFeature(Py_TYPE((x)), Py_TPFLAGS_LONG_SUBCLASS)
+#define PySet_Check(x)       PyObject_TypeCheck((x), pPySet_Type)
+#define PyTuple_Check(x)     PyType_HasFeature(Py_TYPE((x)), Py_TPFLAGS_TUPLE_SUBCLASS)
+#define PyUnicode_Check(x)   PyType_HasFeature(Py_TYPE((x)), Py_TPFLAGS_UNICODE_SUBCLASS)
+
+// There are a few constructs for which placing the stuff in the class scope is not enough
+#ifndef DYNAMICPYTHONAPI_INTERNAL
+#define PyExc_RuntimeError (*pPyExc_RuntimeError)
+#undef PyModule_Create
+#define PyModule_Create(m) DynamicPythonApi::PyModule_Create2((m), PYTHON_API_VERSION)
+#endif
+
+#endif  // DYNAMICPYTHONAPI_H

--- a/Plugins/ScriptingPython/scriptingpython.cpp
+++ b/Plugins/ScriptingPython/scriptingpython.cpp
@@ -241,7 +241,9 @@ QString ScriptingPython::extractError()
         return QString();
 
     PyObject* strErr = PyObject_Repr(value);
-    QString err = QString::fromUtf8(PyUnicode_AsUTF8(strErr));
+    Py_ssize_t size;
+    const char *buf = PyUnicode_AsUTF8AndSize(strErr, &size);
+    QString err = QString::fromUtf8(buf, size);
     PyErr_Clear();
 
     Py_XDECREF(type);
@@ -305,7 +307,11 @@ QVariant ScriptingPython::pythonObjToVariant(PyObject* obj)
         return QVariant();
 
     if (PyUnicode_Check(obj))
-        return QString::fromUtf8(PyUnicode_AsUTF8(obj));
+    {
+        Py_ssize_t size;
+        const char *buf = PyUnicode_AsUTF8AndSize(obj, &size);
+        return QString::fromUtf8(buf, size);
+    }
 
     if (PyLong_Check(obj))
         return PyLong_AsLongLong(obj);
@@ -390,7 +396,9 @@ QVariant ScriptingPython::pythonObjToVariant(PyObject* obj)
     }
 
     PyObject* strObj = PyObject_Repr(obj);
-    QString result = QString::fromUtf8(PyUnicode_AsUTF8(strObj));
+    Py_ssize_t size;
+    const char *buf = PyUnicode_AsUTF8AndSize(strObj, &size);
+    QString result = QString::fromUtf8(buf, size);
     Py_DECREF(strObj);
     return result;
 }
@@ -401,7 +409,9 @@ QString ScriptingPython::pythonObjToString(PyObject* obj)
     if (!strObj)
         return QString();
 
-    QString result = QString::fromUtf8(PyUnicode_AsUTF8(strObj));
+    Py_ssize_t size;
+    const char *buf = PyUnicode_AsUTF8AndSize(strObj, &size);
+    QString result = QString::fromUtf8(buf, size);
     Py_DECREF(strObj);
     return result;
 }
@@ -569,11 +579,17 @@ SqlQueryPtr ScriptingPython::dbCommonEval(PyObject* sqlArg, const char* fnName)
                         SQLITE_ERROR);
         }
 
-        sql = QString::fromUtf8(PyUnicode_AsUTF8(strObj));
+        Py_ssize_t size;
+        const char *buf = PyUnicode_AsUTF8AndSize(strObj, &size);
+        sql = QString::fromUtf8(buf, size);
         Py_DECREF(strObj);
     }
     else
-        sql = QString::fromUtf8(PyUnicode_AsUTF8(sqlArg));
+    {
+        Py_ssize_t size;
+        const char *buf = PyUnicode_AsUTF8AndSize(sqlArg, &size);
+        sql = QString::fromUtf8(buf, size);
+    }
 
     PyThreadState* state = PyThreadState_Get();
     ContextPython* ctx = contexts[state];

--- a/Plugins/ScriptingPython/scriptingpython.qrc
+++ b/Plugins/ScriptingPython/scriptingpython.qrc
@@ -1,4 +1,7 @@
 <RCC>
+    <qresource prefix="/forms">
+        <file>scriptingpython.ui</file>
+    </qresource>
     <qresource prefix="/scriptingpython">
         <file>scriptingpython.png</file>
     </qresource>

--- a/Plugins/ScriptingPython/scriptingpython.ui
+++ b/Plugins/ScriptingPython/scriptingpython.ui
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ScriptingPython</class>
+ <widget class="QWidget" name="ScriptingPython">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>354</width>
+    <height>290</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string notr="true"/>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Python library path</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="FileEdit" name="pythonLibraryPath">
+        <property name="cfg" stdset="0">
+         <string notr="true">ScriptingPython.LibraryPath</string>
+        </property>
+        <property name="dialogTitle" stdset="0">
+         <string>Choose a Python library file</string>
+        </property>
+        <property name="modelName" stdset="0">
+         <string notr="true">ScriptingPython.DiscoveredLibraries</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>FileEdit</class>
+   <extends>QWidget</extends>
+   <header>common/fileedit.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/Plugins/ScriptingPython/staticpythonapi.h
+++ b/Plugins/ScriptingPython/staticpythonapi.h
@@ -1,0 +1,18 @@
+#ifndef STATICPYTHONAPI_H
+#define STATICPYTHONAPI_H
+
+#include <Python.h>
+#include <frameobject.h>
+
+#ifndef METH_FASTCALL
+// In Python pre-3.6 SDK, this is undefined
+#define METH_FASTCALL 0x0080
+#endif
+
+// A couple of compatibility defines for Python SDK before 3.11.
+#if PY_VERSION_HEX < 0x030b0000
+#define PyFrame_GetGlobals(fr) ((fr)->f_globals)
+#define PyFrame_GetLocals(fr) ((fr)->f_locals)
+#endif
+
+#endif  // STATICPYTHONAPI_H

--- a/SQLiteStudio3/coreSQLiteStudio/plugins/populatescript.cpp
+++ b/SQLiteStudio3/coreSQLiteStudio/plugins/populatescript.cpp
@@ -65,6 +65,11 @@ bool PopulateScriptEngine::beforePopulating(Db* db, const QString& table)
     dbAwarePlugin = dynamic_cast<DbAwareScriptingPlugin*>(scriptingPlugin);
 
     context = scriptingPlugin->createContext();
+    if (!context)
+    {
+        notifyError(QObject::tr("Could not get evaluation context, probably the %1 scripting plugin is not configured properly").arg(cfg.PopulateScript.Language.get()));
+        return false;
+    }
 
     QString initCode = cfg.PopulateScript.InitCode.get();
     if (!initCode.trimmed().isEmpty())

--- a/SQLiteStudio3/coreSQLiteStudio/services/impl/functionmanagerimpl.cpp
+++ b/SQLiteStudio3/coreSQLiteStudio/services/impl/functionmanagerimpl.cpp
@@ -191,6 +191,13 @@ void FunctionManagerImpl::evaluateScriptAggregateInitial(ScriptFunction* func, D
     DbAwareScriptingPlugin* dbAwarePlugin = dynamic_cast<DbAwareScriptingPlugin*>(plugin);
 
     ScriptingPlugin::Context* ctx = plugin->createContext();
+    if (!ctx)
+    {
+        aggregateStorage["error"] = true;
+        aggregateStorage["errorMessage"] = tr("Could not create scripting context, probably the plugin is not configured properly");
+        return;
+    }
+
     aggregateStorage["context"] = QVariant::fromValue(ctx);
     FunctionInfoImpl info(func);
 

--- a/SQLiteStudio3/coreSQLiteStudio/sqlitestudio.cpp
+++ b/SQLiteStudio3/coreSQLiteStudio/sqlitestudio.cpp
@@ -347,7 +347,8 @@ void SQLiteStudio::init(const QStringList& cmdListArguments, bool guiAvailable)
     pluginManager->registerPluginType<GeneralPurposePlugin>(QObject::tr("General purpose", "plugin category name"));
     pluginManager->registerPluginType<DbPlugin>(QObject::tr("Database support", "plugin category name"));
     pluginManager->registerPluginType<CodeFormatterPlugin>(QObject::tr("Code formatter", "plugin category name"), "formatterPluginsPage");
-    pluginManager->registerPluginType<ScriptingPlugin>(QObject::tr("Scripting languages", "plugin category name"));
+    pluginManager->registerPluginType<ScriptingPlugin>(QObject::tr("Scripting languages", "plugin category name"),
+                                                       "scriptingPluginsPage");
     pluginManager->registerPluginType<ExportPlugin>(QObject::tr("Exporting", "plugin category name"));
     pluginManager->registerPluginType<ImportPlugin>(QObject::tr("Importing", "plugin category name"));
     pluginManager->registerPluginType<PopulatePlugin>(QObject::tr("Table populating", "plugin category name"));

--- a/SQLiteStudio3/create_macosx_bundle.sh
+++ b/SQLiteStudio3/create_macosx_bundle.sh
@@ -336,14 +336,14 @@ elif [ "$3" = "dist" ]; then
     # Fix sqlite3 file in the image
     embed_libsqlite3 SQLiteStudio.app
 
-    # Fix python dependencies in the image
+    # Fix python dependencies in the image if linked to a Python library
     python_plugin_lib="SQLiteStudio.app/Contents/PlugIns/libScriptingPython.dylib"
     if otool -L "$python_plugin_lib" | grep -q /opt/local/Library/Frameworks/Python.framework; then
         python_from_macports="yes"
         _ref="/opt/local/Library/Frameworks/Python.framework/Versions/$PYTHON_VERSION/Python"
     else
         python_from_macports="no"
-        run rm -f SQLiteStudio.app/Contents/Frameworks/libpython* SQLiteStudio.app/Contents/Frameworks/libint*
+        run rm -f SQLiteStudio.app/Contents/Frameworks/libpython*
         _ref="@loader_path/../Frameworks/libpython$PYTHON_VERSION.dylib"
     fi
     run install_name_tool -change "$_ref" "libpython$PYTHON_VERSION.dylib" "$python_plugin_lib"

--- a/SQLiteStudio3/guiSQLiteStudio/common/fileedit.cpp
+++ b/SQLiteStudio3/guiSQLiteStudio/common/fileedit.cpp
@@ -3,6 +3,7 @@
 #include "uiconfig.h"
 #include <QHBoxLayout>
 #include <QLineEdit>
+#include <QComboBox>
 #include <QToolButton>
 #include <QFileDialog>
 
@@ -40,6 +41,16 @@ QString FileEdit::getDialogTitle() const
 QString FileEdit::getFilters() const
 {
     return filters;
+}
+
+QAbstractItemModel* FileEdit::getChoicesModel() const
+{
+    return choicesModel;
+}
+
+QVariant FileEdit::getChoicesModelName() const
+{
+    return choicesModelName;
 }
 
 void FileEdit::browse()
@@ -95,4 +106,40 @@ void FileEdit::setFilters(QString arg)
         filters = arg;
         emit filtersChanged(arg);
     }
+}
+
+void FileEdit::setChoicesModel(QAbstractItemModel* arg)
+{
+    if (choicesModel != arg)
+    {
+        disconnect(lineEdit, SIGNAL(textChanged(QString)), this, SLOT(lineTextChanged()));
+        choicesModel = arg;
+        if (choicesModel != nullptr && combo == nullptr)
+        {
+            combo = new QComboBox();
+            combo->setEditable(true);
+            layout()->replaceWidget(lineEdit, combo);
+            delete lineEdit;
+            lineEdit = combo->lineEdit();
+        }
+        else if (choicesModel == nullptr && combo != nullptr)
+        {
+            lineEdit = new QLineEdit();
+            lineEdit->setText(file);
+            layout()->replaceWidget(combo, lineEdit);
+            delete combo;
+            combo = nullptr;
+        }
+        if (combo != nullptr)
+        {
+            combo->setModel(choicesModel);
+            lineEdit->setText(file);
+        }
+        connect(lineEdit, SIGNAL(textChanged(QString)), this, SLOT(lineTextChanged()));
+    }
+}
+
+void FileEdit::setChoicesModelName(QVariant arg)
+{
+    choicesModelName = arg;
 }

--- a/SQLiteStudio3/guiSQLiteStudio/common/fileedit.h
+++ b/SQLiteStudio3/guiSQLiteStudio/common/fileedit.h
@@ -3,9 +3,12 @@
 
 #include "guiSQLiteStudio_global.h"
 #include <QWidget>
+#include <QVariant>
 
 class QLineEdit;
 class QToolButton;
+class QComboBox;
+class QAbstractItemModel;
 
 class GUI_API_EXPORT FileEdit : public QWidget
 {
@@ -15,6 +18,7 @@ class GUI_API_EXPORT FileEdit : public QWidget
         Q_PROPERTY(bool save READ getSave WRITE setSave NOTIFY saveChanged)
         Q_PROPERTY(QString dialogTitle READ getDialogTitle WRITE setDialogTitle NOTIFY dialogTitleChanged)
         Q_PROPERTY(QString filters READ getFilters WRITE setFilters NOTIFY filtersChanged)
+        Q_PROPERTY(QVariant modelName READ getChoicesModelName WRITE setChoicesModelName)
 
     public:
         explicit FileEdit(QWidget *parent = 0);
@@ -23,14 +27,20 @@ class GUI_API_EXPORT FileEdit : public QWidget
         bool getSave() const;
         QString getDialogTitle() const;
         QString getFilters() const;
+        QAbstractItemModel* getChoicesModel() const;
+        QVariant getChoicesModelName() const;
+        void setChoicesModel(QAbstractItemModel* arg);
 
     private:
         QString file;
         bool save = false;
         QString dialogTitle;
         QString filters;
+        QVariant choicesModelName;
+        QAbstractItemModel* choicesModel = nullptr;
         QLineEdit* lineEdit = nullptr;
         QToolButton* button = nullptr;
+        QComboBox* combo = nullptr;
 
     signals:
         void fileChanged(QString arg);
@@ -47,6 +57,7 @@ class GUI_API_EXPORT FileEdit : public QWidget
         void setSave(bool arg);
         void setDialogTitle(QString arg);
         void setFilters(QString arg);
+        void setChoicesModelName(QVariant arg);
 };
 
 #endif // FILEEDIT_H

--- a/SQLiteStudio3/guiSQLiteStudio/configmapper.h
+++ b/SQLiteStudio3/guiSQLiteStudio/configmapper.h
@@ -84,6 +84,7 @@ class GUI_API_EXPORT ConfigMapper : public QObject
         void applyConfigToWidget(QWidget *widget, CfgEntry* cfgEntry, const QVariant& configValue);
         void handleSpecialWidgets(QWidget *widget, const QHash<QString, CfgEntry*>& allConfigEntries);
         void handleConfigComboBox(QWidget *widget, const QHash<QString, CfgEntry*>& allConfigEntries);
+        void handleFileEdit(QWidget* widget, const QHash<QString, CfgEntry*>& allConfigEntries);
         void connectCommonNotifierToWidget(QWidget *widget, CfgEntry* key);
         bool connectCustomNotifierToWidget(QWidget *widget, CfgEntry* cfgEntry);
         void applyCommonConfigToWidget(QWidget *widget, const QVariant& value, CfgEntry* cfgEntry);
@@ -128,6 +129,7 @@ class GUI_API_EXPORT ConfigMapper : public QObject
         void entryChanged(const QVariant& newValue);
         void uiConfigEntryChanged();
         void updateConfigComboModel(const QVariant& value);
+        void updateFileEditChoicesModel(const QVariant& value);
         void notifiableConfigKeyChanged();
 
     signals:

--- a/SQLiteStudio3/guiSQLiteStudio/dialogs/configdialog.ui
+++ b/SQLiteStudio3/guiSQLiteStudio/dialogs/configdialog.ui
@@ -228,6 +228,14 @@
                <string notr="true">formatterPluginsPage</string>
               </property>
              </item>
+             <item>
+              <property name="text">
+               <string>Scripting languages</string>
+              </property>
+              <property name="statusTip">
+               <string notr="true">scriptingPluginsPage</string>
+              </property>
+             </item>
             </item>
            </widget>
           </item>


### PR DESCRIPTION
This PR is assumed to be applied on top of #5047 and #5048.

It adds support for runtime binding to Python library configured by user. It also adds some needed UI features.

![Screenshot 2024-08-19 at 04 22 41](https://github.com/user-attachments/assets/46bb82b1-c705-4ac9-9e5b-585bd78d7fcd)

Tested on: MacOS 10.14, Python SDK 3.4–3.13, Python library 2.7–3.13.
Fixes: #4662.