### PR TITLE
Re-enable deprecated  C++ exceptions handlers when building with modern Clang

### DIFF
--- a/SQLiteStudio3/coreSQLiteStudio/coreSQLiteStudio.pro
+++ b/SQLiteStudio3/coreSQLiteStudio/coreSQLiteStudio.pro
@@ -28,6 +28,10 @@ win32: {
         THE_DEST ~= s,/,\\,g
         QMAKE_POST_LINK += "$$QMAKE_COPY $$THE_FILE $$THE_DEST $$escape_expand(\\n\\t);"
     }
+
+    equals(QMAKE_CXX, clang++) {
+        QMAKE_CXXFLAGS += -D_LIBCPP_ENABLE_CXX17_REMOVED_UNEXPECTED_FUNCTIONS
+    }
 }
 
 linux: {


### PR DESCRIPTION
Building with recent versions of Clang fail with deprecated (since C++11) exception handlers with:

```cpp
In file included from ../../SQLiteStudio3/coreSQLiteStudio/chillout/windows/windowscrashhandler.cpp:7:
../../SQLiteStudio3/coreSQLiteStudio/chillout/windows/windowscrashhandler.h:45:14: error: no type named 'unexpected_handler' in namespace 'std'
   45 |         std::unexpected_handler m_prevUnexp;      // Previous unexpected handler
      |         ~~~~~^
../../SQLiteStudio3/coreSQLiteStudio/chillout/windows/windowscrashhandler.cpp:479:37: error: no member named 'set_unexpected' in namespace 'std'
  479 |         handlers.m_prevUnexp = std::set_unexpected(UnexpectedHandler);
      |                                ~~~~~^
../../SQLiteStudio3/coreSQLiteStudio/chillout/windows/windowscrashhandler.cpp:513:18: error: no member named 'set_unexpected' in namespace 'std'
  513 |             std::set_unexpected(handlers->m_prevUnexp);
      |             ~~~~~^
```

This enables these exceptions classes again.