### PR TITLE
Fix linux compilation

### DIFF
--- a/Plugins/ScriptingPython/ScriptingPython.pro
+++ b/Plugins/ScriptingPython/ScriptingPython.pro
@@ -23,6 +23,10 @@ dynamic_python {
     DEFINES += PYTHON_DYNAMIC_BINDING
     SOURCES += dynamicpythonapi.cpp
     HEADERS += dynamicpythonapi.h
+    linux : {
+        CONFIG += link_pkgconfig
+        PKGCONFIG += python3
+    }
 }
 
 !dynamic_python {

--- a/scripts/linux/compile.sh
+++ b/scripts/linux/compile.sh
@@ -36,15 +36,14 @@ else
 fi
 
 if [ -d $parent_dir/output ]; then
-	read -p "Directory $parent_dir/output already exists. The script will delete and recreate it. Is that okay? (y/N) : " yn
+	read -p "Directory $parent_dir/output already exists. Should it be deleted? (y/N) : " yn
 	case $yn in
 	    [Yy]* ) rm -rf $parent_dir/output ;;
-	    * ) echo "Aborted."; exit;;
 	esac
 fi
 
 cd $parent_dir
-mkdir output output/build output/build/Plugins
+mkdir -p output output/build output/build/Plugins
 
 cd output/build
 $QMAKE CONFIG+=portable ../../SQLiteStudio3


### PR DESCRIPTION
This fixes the compilation instructions for ScriptingPython : the Python.h file was not found because no ``-I`` was added in the generated Makefile (the exact location is dependant on the exact version of python available, eg. ``-I/usr/include/python3.12 -I/usr/include/x86_64-linux-gnu/python3.12``).

This also changes the linux compilation script to allow compiling to a non-empty output folder. This greatly improves compilation time when changing just some files in the source.