### PR TITLE
Remove STRINGIFY from DIR constants

### DIFF
--- a/SQLiteStudio3/coreSQLiteStudio/coreSQLiteStudio.pro
+++ b/SQLiteStudio3/coreSQLiteStudio/coreSQLiteStudio.pro
@@ -34,8 +34,8 @@ win32: {
     }
 }
 
-linux: {
-    DEFINES += SYS_PLUGINS_DIR=$$LIBDIR/sqlitestudio
+unix:!macx: {
+    DEFINES += "SYS_PLUGINS_DIR=\"\\\"$$LIBDIR/sqlitestudio\\\"\""
     portable: {
         DESTDIR = $$DESTDIR/lib
     }

--- a/SQLiteStudio3/coreSQLiteStudio/services/impl/pluginmanagerimpl.cpp
+++ b/SQLiteStudio3/coreSQLiteStudio/services/impl/pluginmanagerimpl.cpp
@@ -29,11 +29,11 @@ void PluginManagerImpl::init()
         pluginDirs += envDirs.split(PATH_LIST_SEPARATOR);
 
 #ifdef PLUGINS_DIR
-    pluginDirs += STRINGIFY(PLUGINS_DIR);
+    pluginDirs += PLUGINS_DIR;
 #endif
 
 #ifdef SYS_PLUGINS_DIR
-    pluginDirs += STRINGIFY(SYS_PLUGINS_DIR);
+    pluginDirs += SYS_PLUGINS_DIR;
 #endif
 
 #ifdef Q_OS_MACX

--- a/SQLiteStudio3/coreSQLiteStudio/services/impl/sqliteextensionmanagerimpl.cpp
+++ b/SQLiteStudio3/coreSQLiteStudio/services/impl/sqliteextensionmanagerimpl.cpp
@@ -58,7 +58,7 @@ void SqliteExtensionManagerImpl::scanExtensionDirs()
         extensionDirs += envDirs.split(PATH_LIST_SEPARATOR);
 
 #ifdef SQLITE_EXTENSIONS_DIR
-    extensionDirs += STRINGIFY(SQLITE_EXTENSIONS_DIR);
+    extensionDirs += SQLITE_EXTENSIONS_DIR;
 #endif
 
     for (QString& extDirPath : extensionDirs)

--- a/SQLiteStudio3/guiSQLiteStudio/formmanager.cpp
+++ b/SQLiteStudio3/guiSQLiteStudio/formmanager.cpp
@@ -114,7 +114,7 @@ void FormManager::load()
     formDirs += PLUGINS->getPluginDirs();
 
 #ifdef FORMS_DIR
-    formDirs += STRINGIFY(FORMS_DIR);
+    formDirs += FORMS_DIR;
 #endif
 
     for (QString dirPath : formDirs)

--- a/SQLiteStudio3/guiSQLiteStudio/iconmanager.cpp
+++ b/SQLiteStudio3/guiSQLiteStudio/iconmanager.cpp
@@ -42,7 +42,7 @@ void IconManager::init()
         iconDirs += envDirs.split(PATH_LIST_SEPARATOR);
 
 #ifdef ICONS_DIR
-    iconDirs += STRINGIFY(ICONS_DIR);
+    iconDirs += ICONS_DIR;
 #endif
 
     iconFileExtensions << "*.png" << "*.PNG" << "*.jpg" << "*.JPG" << "*.svg" << "*.SVG";


### PR DESCRIPTION
STRINGIFY turns /usr/lib/x86_64-linux-gnu/sqlitestudio into "/usr/lib/x86_64-1-gnu/sqlitestudio", since they are actually a series of tokens and "linux" is defined "1".

Moreover, if it contains more than one space, the actual path is lost forever.

Instead of getting blood out of stone, get rid of STRINGIFY and use a valid string for path constants instead.