### PR TITLE
Fix SQLite3 link CMake warning

### DIFF
--- a/Letos/Tests/TestUtils/CMakeLists.txt
+++ b/Letos/Tests/TestUtils/CMakeLists.txt
@@ -36,7 +36,7 @@ if(NOT CUSTOM_SQLITE3)
 endif()
 target_link_libraries(TestUtils PUBLIC
     Qt::Core
-    SQLite::SQLite3
+    SQLite3::SQLite3
     coreLetos
 )
 target_link_libraries(TestUtils PUBLIC

--- a/Letos/cmake/custom_sqlite3.cmake
+++ b/Letos/cmake/custom_sqlite3.cmake
@@ -24,8 +24,8 @@ if(CUSTOM_SQLITE3)
 	target_include_directories(SQLiteHeaders INTERFACE
 		"${_sqlite_include}"
 	)
-	add_library(SQLite::SQLite3 UNKNOWN IMPORTED)
-	set_target_properties(SQLite::SQLite3 PROPERTIES
+	add_library(SQLite3::SQLite3 UNKNOWN IMPORTED)
+	set_target_properties(SQLite3::SQLite3 PROPERTIES
 		IMPORTED_LOCATION "${_sqlite_lib}"
 		INTERFACE_INCLUDE_DIRECTORIES "${_sqlite_include}"
 	)

--- a/Letos/core/CMakeLists.txt
+++ b/Letos/core/CMakeLists.txt
@@ -422,7 +422,7 @@ target_compile_definitions(coreLetos PRIVATE
     CORE_LIBRARY
 )
 target_link_libraries(coreLetos PUBLIC
-    SQLite::SQLite3
+    SQLite3::SQLite3
 )
 target_link_libraries(coreLetos PRIVATE
     Qt::Core


### PR DESCRIPTION
```
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at Tests/TestUtils/CMakeLists.txt:37 (target_link_libraries):
  The library that is being linked to, SQLite::SQLite3, is marked as being
  deprecated by the owner.  The message provided by the developer is:

  The target name SQLite::SQLite3 is deprecated.  Please use SQLite3::SQLite3
  instead.
```