### PR TITLE
Fix double decref after PyList_SetItem in variantToPythonObj

### DIFF
--- a/Plugins/ScriptingPython/scriptingpython.cpp
+++ b/Plugins/ScriptingPython/scriptingpython.cpp
@@ -651,7 +651,6 @@ PyObject* ScriptingPython::variantToPythonObj(const QVariant& value)
             {
                 PyObject* subObj = variantToPythonObj(item);
                 PyList_SetItem(obj, pos++, subObj);
-                Py_DECREF(subObj);
             }
 
             break;
@@ -666,7 +665,6 @@ PyObject* ScriptingPython::variantToPythonObj(const QVariant& value)
             {
                 PyObject* subObj = stringToPythonObj(item);
                 PyList_SetItem(obj, pos++, subObj);
-                Py_DECREF(subObj);
             }
 
             break;


### PR DESCRIPTION
## Summary
Remove erroneous `Py_DECREF(subObj)` calls after `PyList_SetItem()` in `ScriptingPython::variantToPythonObj()`.

`PyList_SetItem()` steals the reference to the inserted item, so decrementing it afterward can leave the Python list with a dangling pointer.

Fixes #5699

## Test plan
- Reviewed Python C API reference counting semantics for `PyList_SetItem()`
- Verified the affected code only used this unsafe pattern in the `QVariantList` and `QStringList` conversion paths